### PR TITLE
DATAKV-96 - Add 'findAll' method to QuerydslKeyValueRepository which accepts a querydsl Predicate and a Sort.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>0.1.0.BUILD-SNAPSHOT</version>
+	<version>0.1.0.DATAKV-96-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 
@@ -18,7 +18,7 @@
 
 	<properties>
 		<dist.key>DATAKV</dist.key>
-		<springdata.commons>1.10.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.10.0.DATACMNS-554-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/QuerydslKeyValueRepository.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/QuerydslKeyValueRepository.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.keyvalue.core.KeyValueOperations;
 import org.springframework.data.keyvalue.repository.KeyValueRepository;
 import org.springframework.data.querydsl.EntityPathResolver;
@@ -43,6 +44,7 @@ import com.mysema.query.types.path.PathBuilder;
  * 
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Thomas Darimont
  * @param <T> the domain type to manage
  * @param <ID> the identififer type of the domain type
  */
@@ -113,6 +115,14 @@ public class QuerydslKeyValueRepository<T, ID extends Serializable> extends Simp
 		query.orderBy(orders);
 
 		return query.list(builder);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Sort)
+	 */
+	@Override
+	public Iterable<T> findAll(Predicate predicate, Sort sort) {
+		return findAll(predicate, toOrderSpecifier(sort, builder));
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/map/AbstractRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/map/AbstractRepositoryUnitTests.java
@@ -30,6 +30,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.keyvalue.Person;
+import org.springframework.data.keyvalue.QPerson;
 import org.springframework.data.keyvalue.core.KeyValueOperations;
 import org.springframework.data.keyvalue.core.KeyValueTemplate;
 import org.springframework.data.keyvalue.repository.KeyValueRepository;
@@ -41,6 +42,7 @@ import org.springframework.data.repository.CrudRepository;
  * 
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public abstract class AbstractRepositoryUnitTests<T extends AbstractRepositoryUnitTests.PersonRepository> {
 
@@ -49,6 +51,8 @@ public abstract class AbstractRepositoryUnitTests<T extends AbstractRepositoryUn
 	protected static final Person TYRION = new Person("tyrion", 17);
 
 	protected static List<Person> LENNISTERS = Arrays.asList(CERSEI, JAIME, TYRION);
+
+	protected final QPerson person = QPerson.person;
 
 	protected T repository;
 	protected KeyValueRepositoryFactory factory;

--- a/src/test/java/org/springframework/data/map/QuerydslKeyValueRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/map/QuerydslKeyValueRepositoryUnitTests.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.data.map;
 
-import static org.hamcrest.collection.IsCollectionWithSize.*;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.*;
-import static org.hamcrest.collection.IsIterableContainingInOrder.*;
-import static org.hamcrest.core.Is.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+
+import java.util.List;
 
 import org.junit.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.keyvalue.Person;
 import org.springframework.data.keyvalue.QPerson;
@@ -33,11 +33,14 @@ import org.springframework.data.map.QuerydslKeyValueRepositoryUnitTests.QPersonR
 import org.springframework.data.querydsl.QSort;
 import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 
+import com.google.common.collect.Lists;
+
 /**
  * Unit tests for {@link QuerydslKeyValueRepository}.
  * 
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Thomas Darimont
  */
 public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitTests<QPersonRepository> {
 
@@ -163,6 +166,22 @@ public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitT
 		repository.save(LENNISTERS);
 
 		assertThat(repository.exists(QPerson.person.age.eq(CERSEI.getAge())), is(true));
+	}
+
+	/**
+	 * @see DATAKV-96
+	 */
+	@Test
+	public void shouldSupportFindAllWithPredicateAndSort() {
+
+		repository.save(LENNISTERS);
+
+		List<Person> users = Lists.newArrayList(repository.findAll(person.age.gt(0), new Sort(Direction.ASC, "firstname")));
+
+		assertThat(users, hasSize(3));
+		assertThat(users.get(0).getFirstname(), is(CERSEI.getFirstname()));
+		assertThat(users.get(2).getFirstname(), is(TYRION.getFirstname()));
+		assertThat(users, hasItems(CERSEI, JAIME, TYRION));
 	}
 
 	/* 


### PR DESCRIPTION
We now support findAll on QuerydslKeyValueRepository that accepts a Querydsl Predicate and a Sort.