### PR TITLE
Update Maven download instructions in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,12 +16,25 @@ Download the jar though Maven:
 ```xml
 <dependency>
   <groupId>org.springframework.data</groupId>
-  <artifactId>spring-data-key-value</artifactId>
+  <artifactId>spring-data-keyvalue</artifactId>
   <version>0.1.0.BUILD-SNAPSHOT</version>
 </dependency>
+...
+
+For snapshot versions, make sure you include the spring snapshots repository:
+
+```xml
+<repositories>
+  <repository>
+    <id>spring-libs-snapshot</id>
+    <url>http://repo.spring.io/libs-snapshot</url>
+  </repository>
+</repositories>
 ```
 
-The `ConcurrentHashMap` based default configuration looks like this: 
+
+
+The `ConcurrentHashMap` based default configuration looks like this:
 ```java
 @Configuration
 @EnableMapRepositories("com.acme.repositories")


### PR DESCRIPTION
The Maven download instructions are currently out of date.  The actual artifact ID in the spring repository is `spring-data-keyvalue`, not `spring-data-key-value`.

I've also added an additional note about adding the spring snapshot repository to your pom when pointing at SNAPSHOT versions (which is currently the only versions available.)

Just a small contribution, but I hope to help more in the future :-)