### PR TITLE
DATAKV-102 - Add possibility to iterate over available keys.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>0.1.0.BUILD-SNAPSHOT</version>
+	<version>0.1.0.DATAKV-102-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
@@ -74,12 +74,20 @@ public interface KeyValueAdapter extends DisposableBean {
 	Iterable<?> getAllOf(Serializable keyspace);
 
 	/**
-	 * Returns a {@link KeyValueIterator} that iterates over all entries. 
+	 * Returns a {@link KeyValueIterator} that iterates over all entries.
 	 * 
-	 * @param keyspace
+	 * @param keyspace must not be {@literal null}.
 	 * @return
 	 */
 	KeyValueIterator<? extends Serializable, ?> entries(Serializable keyspace);
+
+	/**
+	 * Returns all keys available in {@literal keyspace}.
+	 * 
+	 * @param keyspace must not be {@literal null}.
+	 * @return empty {@link Iterable} if no keys available or keyspace unknown.
+	 */
+	Iterable<? extends Serializable> keys(Serializable keyspace);
 
 	/**
 	 * Remove all objects of given type.

--- a/src/main/java/org/springframework/data/map/MapKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/map/MapKeyValueAdapter.java
@@ -104,7 +104,6 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 		return get(id, keyspace) != null;
 	}
 
-
 	/* (non-Javadoc)
 	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#count(java.io.Serializable)
 	 */
@@ -151,6 +150,15 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 	@Override
 	public KeyValueIterator<Serializable, ?> entries(Serializable keyspace) {
 		return new ForwardingKeyValueIterator<Serializable, Object>(getKeySpaceMap(keyspace).entrySet().iterator());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#keys(java.io.Serializable)
+	 */
+	@Override
+	public Iterable<Serializable> keys(Serializable keyspace) {
+		return getKeySpaceMap(keyspace).keySet();
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/map/MapKeyValueAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/map/MapKeyValueAdapterUnitTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.map;
 
+import static org.hamcrest.collection.IsEmptyIterable.*;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.*;
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsEqual.*;
@@ -24,6 +25,8 @@ import static org.springframework.data.keyvalue.test.util.IsEntry.*;
 
 import java.io.Serializable;
 
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.hamcrest.collection.IsIterableWithSize;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.data.keyvalue.core.KeyValueIterator;
@@ -193,7 +196,7 @@ public class MapKeyValueAdapterUnitTests {
 	 * @see DATAKV-99
 	 */
 	@Test
-	public void scanShouldIterateOverAvailableEntries() {
+	public void entriesShouldIterateOverAvailableEntries() {
 
 		adapter.put("1", object1, COLLECTION_1);
 		adapter.put("2", object2, COLLECTION_1);
@@ -209,7 +212,7 @@ public class MapKeyValueAdapterUnitTests {
 	 * @see DATAKV-99
 	 */
 	@Test
-	public void scanShouldReturnEmptyIteratorWhenNoElementsAvailable() {
+	public void entriesShouldReturnEmptyIteratorWhenNoElementsAvailable() {
 		assertThat(adapter.entries(COLLECTION_1).hasNext(), is(false));
 	}
 
@@ -217,7 +220,7 @@ public class MapKeyValueAdapterUnitTests {
 	 * @see DATAKV-99
 	 */
 	@Test
-	public void scanDoesNotMixResultsFromMultipleKeyspaces() {
+	public void entriesShouldNotMixResultsFromMultipleKeyspaces() {
 
 		adapter.put("1", object1, COLLECTION_1);
 		adapter.put("2", object2, COLLECTION_2);
@@ -226,6 +229,40 @@ public class MapKeyValueAdapterUnitTests {
 
 		assertThat(iterator.next(), isEntry("1", object1));
 		assertThat(iterator.hasNext(), is(false));
+	}
+
+	/**
+	 * @see DATAKV-102
+	 */
+	@Test
+	public void keysShouldReturnAvailableKeys() {
+
+		adapter.put("1", object1, COLLECTION_1);
+		adapter.put("2", object2, COLLECTION_1);
+
+		Iterable<Serializable> iterable = adapter.keys(COLLECTION_1);
+
+		assertThat(iterable, IsIterableContainingInAnyOrder.<Serializable> containsInAnyOrder("1", "2"));
+	}
+
+	/**
+	 * @see DATAKV-102
+	 */
+	@Test
+	public void keyShouldReturnEmptyIterableWhenNoElementsAvailable() {
+		assertThat(adapter.keys(COLLECTION_1), emptyIterable());
+	}
+
+	/**
+	 * @see DATAKV-102
+	 */
+	@Test
+	public void keysShouldNotMixResultsFromMultipleKeyspaces() {
+
+		adapter.put("1", object1, COLLECTION_1);
+		adapter.put("2", object2, COLLECTION_2);
+
+		assertThat(adapter.keys(COLLECTION_1), IsIterableWithSize.<Serializable> iterableWithSize(1));
 	}
 
 	static class SimpleObject {


### PR DESCRIPTION
`KeyValueAdapter` now exposes `keys(Serializable keyspace)` which allows to retrieve all keys contained in that specific region.

Fixed false test names (scan vs. entries (see DATAKV-99)) along the way.