### PR TITLE
DATAKV-104 - Refactor event handling according to design in Spring Data MongoDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>0.1.0.BUILD-SNAPSHOT</version>
+	<version>0.1.0.DATAKV-104-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
@@ -25,10 +25,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -52,7 +50,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Gierke
  * @author Thomas Darimont
  */
-public class KeyValueTemplate implements KeyValueOperations, ApplicationContextAware {
+public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPublisherAware {
 
 	private static final PersistenceExceptionTranslator DEFAULT_PERSISTENCE_EXCEPTION_TRANSLATOR = new KeyValuePersistenceExceptionTranslator();
 
@@ -61,7 +59,8 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 	private final MappingContext<? extends PersistentEntity<?, ? extends PersistentProperty<?>>, ? extends PersistentProperty<?>> mappingContext;
 	private final IdentifierGenerator identifierGenerator;
 	private ApplicationEventPublisher eventPublisher;
-	private final Set<KeyValueEvent.Type> eventTypesToPublish = new HashSet<KeyValueEvent.Type>(4);
+	private boolean publishEvents = true;
+	private final Set<Class<?>> eventTypesToPublish = new HashSet<Class<?>>(0);
 	private PersistenceExceptionTranslator exceptionTranslator = DEFAULT_PERSISTENCE_EXCEPTION_TRANSLATOR;
 
 	/**
@@ -122,7 +121,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 
 		final String keyspace = resolveKeySpace(objectToInsert.getClass());
 
-		potentiallyPublishEvent(KeyValueEvent.beforeInsert(this, keyspace, id, objectToInsert));
+		potentiallyPublishEvent(KeyValueEvent.beforeInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
 
 		execute(new KeyValueCallback<Void>() {
 
@@ -139,7 +138,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 			}
 		});
 
-		potentiallyPublishEvent(KeyValueEvent.afterInsert(this, keyspace, id, objectToInsert));
+		potentiallyPublishEvent(KeyValueEvent.afterInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
 	}
 
 	/*
@@ -173,18 +172,18 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 
 		final String keyspace = resolveKeySpace(objectToUpdate.getClass());
 
-		potentiallyPublishEvent(KeyValueEvent.beforeUpdate(this, keyspace, id, objectToUpdate));
+		potentiallyPublishEvent(KeyValueEvent.beforeUpdate(id, keyspace, objectToUpdate.getClass(), objectToUpdate));
 
-		execute(new KeyValueCallback<Void>() {
+		Object existing = execute(new KeyValueCallback<Object>() {
 
 			@Override
-			public Void doInKeyValue(KeyValueAdapter adapter) {
-				adapter.put(id, objectToUpdate, keyspace);
-				return null;
+			public Object doInKeyValue(KeyValueAdapter adapter) {
+				return adapter.put(id, objectToUpdate, keyspace);
 			}
 		});
 
-		potentiallyPublishEvent(KeyValueEvent.afterUpdate(this, keyspace, id, objectToUpdate));
+		potentiallyPublishEvent(KeyValueEvent
+				.afterUpdate(id, keyspace, objectToUpdate.getClass(), objectToUpdate, existing));
 	}
 
 	/*
@@ -232,7 +231,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 
 		final String keyspace = resolveKeySpace(type);
 
-		potentiallyPublishEvent(KeyValueEvent.beforeGet(this, keyspace, id));
+		potentiallyPublishEvent(KeyValueEvent.beforeGet(id, keyspace, type));
 
 		T result = execute(new KeyValueCallback<T>() {
 
@@ -250,7 +249,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 			}
 		});
 
-		potentiallyPublishEvent(KeyValueEvent.afterGet(this, keyspace, id, result));
+		potentiallyPublishEvent(KeyValueEvent.afterGet(id, keyspace, type, result));
 
 		return result;
 	}
@@ -266,7 +265,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 
 		final String keyspace = resolveKeySpace(type);
 
-		potentiallyPublishEvent(KeyValueEvent.beforeDelete(this, keyspace));
+		potentiallyPublishEvent(KeyValueEvent.beforeDropKeySpace(keyspace, type));
 
 		execute(new KeyValueCallback<Void>() {
 
@@ -278,7 +277,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 			}
 		});
 
-		potentiallyPublishEvent(KeyValueEvent.afterDelete(this, keyspace));
+		potentiallyPublishEvent(KeyValueEvent.afterDropKeySpace(keyspace, type));
 	}
 
 	/*
@@ -302,12 +301,12 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 	@Override
 	public <T> T delete(final Serializable id, final Class<T> type) {
 
-		Assert.notNull(id, "Id for object to be inserted must not be null!");
+		Assert.notNull(id, "Id for object to be deleted must not be null!");
 		Assert.notNull(type, "Type to delete must not be null!");
 
 		final String keyspace = resolveKeySpace(type);
 
-		potentiallyPublishEvent(KeyValueEvent.beforeDelete(this, keyspace, id));
+		potentiallyPublishEvent(KeyValueEvent.beforeDelete(id, keyspace, type));
 
 		T result = execute(new KeyValueCallback<T>() {
 
@@ -318,7 +317,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 			}
 		});
 
-		potentiallyPublishEvent(KeyValueEvent.afterDelete(this, keyspace, id, result));
+		potentiallyPublishEvent(KeyValueEvent.afterDelete(id, keyspace, type, result));
 
 		return result;
 	}
@@ -459,24 +458,28 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.context.ApplicationContextAware#setApplicationContext(org.springframework.context.ApplicationContext)
+	 * @see org.springframework.context.ApplicationEventPublisherAware#setApplicationEventPublisher(org.springframework.context.ApplicationEventPublisher)
 	 */
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-		eventPublisher = applicationContext;
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.eventPublisher = applicationEventPublisher;
 	}
 
 	/**
 	 * Define the event types to publish via {@link ApplicationEventPublisher}.
 	 * 
-	 * @param eventTypesToPublish use {@literal null} or {@link Collections#emptySet()} to disable publishing.
+	 * @param eventTypesToPublish use {@literal null} or {@link Collections#emptySet()} to stop publishing.
 	 */
-	public void setEventTypesToPublish(Set<KeyValueEvent.Type> eventTypesToPublish) {
+	public void setEventTypesToPublish(Set<Class<? extends KeyValueEvent>> eventTypesToPublish) {
 
 		this.eventTypesToPublish.clear();
 
 		if (!CollectionUtils.isEmpty(eventTypesToPublish)) {
+
+			this.publishEvents = true;
 			this.eventTypesToPublish.addAll(eventTypesToPublish);
+		} else {
+			this.publishEvents = false;
 		}
 	}
 
@@ -521,7 +524,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationContextA
 			return;
 		}
 
-		if (eventTypesToPublish.contains(event.getType()) || eventTypesToPublish.contains(KeyValueEvent.Type.ANY)) {
+		if (publishEvents && (eventTypesToPublish.isEmpty() || eventTypesToPublish.contains(event.getClass()))) {
 			eventPublisher.publishEvent(event);
 		}
 	}

--- a/src/main/java/org/springframework/data/keyvalue/core/event/KeyValueEvent.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/event/KeyValueEvent.java
@@ -28,33 +28,16 @@ import org.springframework.context.ApplicationEvent;
  * @author Thomas Darimont
  * @param <T>
  */
-public class KeyValueEvent extends ApplicationEvent {
+public class KeyValueEvent<T> extends ApplicationEvent {
 
 	private static final long serialVersionUID = -7128527253428193044L;
 
-	public enum Type {
-		ANY, BEFORE_INSERT, AFTER_INSERT, BEFORE_UPDATE, AFTER_UPDATE, BEFORE_DELETE, AFTER_DELETE, BEFORE_GET, AFTER_GET
-	}
-
-	private final Type type;
 	private final String keyspace;
-	private final Serializable id;
-	private final Object value;
 
-	protected KeyValueEvent(Object source, Type type, String keyspace, Serializable id, Object value) {
-		
+	protected KeyValueEvent(Object source, String keyspace) {
+
 		super(source);
-		this.type = type;
 		this.keyspace = keyspace;
-		this.id = id;
-		this.value = value;
-	}
-
-	/**
-	 * @return {@link Type} of event. Never {@literal null}.
-	 */
-	public Type getType() {
-		return type;
 	}
 
 	/**
@@ -64,114 +47,374 @@ public class KeyValueEvent extends ApplicationEvent {
 		return keyspace;
 	}
 
-	/**
-	 * @return can be {@literal null}.
-	 */
-	public Serializable getId() {
-		return id;
-	}
-
-	/**
-	 * @return can be {@literal null}.
-	 */
-	public Object getValue() {
-		return value;
-	}
-
 	@Override
 	public String toString() {
-		return "KeyValueEvent [type=" + type + ", keyspace=" + keyspace + ", id=" + id + "]";
+		return "KeyValueEvent [keyspace=" + keyspace + ", source=" + getSource() + "]";
 	}
 
-	public static GetEvent beforeGet(Object source, String keyspace, Serializable id) {
-		return new GetEvent(source, Type.BEFORE_GET, keyspace, id, null);
+	/**
+	 * Create new {@link BeforeGetEvent}.
+	 * 
+	 * @param id
+	 * @param keySpace
+	 * @param type
+	 * @return
+	 */
+	public static <T> BeforeGetEvent<T> beforeGet(Serializable id, String keySpace, Class<T> type) {
+		return new BeforeGetEvent<T>(id, keySpace, type);
 	}
 
-	public static GetEvent afterGet(Object source, String keyspace, Serializable id, Object value) {
-		return new GetEvent(source, Type.AFTER_GET, keyspace, id, value);
+	/**
+	 * Create new {@link AfterGetEvent}.
+	 * 
+	 * @param id
+	 * @param keySpace
+	 * @param type
+	 * @param value
+	 * @return
+	 */
+	public static <T> AfterGetEvent<T> afterGet(Serializable id, String keySpace, Class<T> type, T value) {
+		return new AfterGetEvent<T>(id, keySpace, type, value);
 	}
 
-	public static InsertEvent beforeInsert(Object source, String keyspace, Serializable id, Object value) {
-		return new InsertEvent(source, Type.BEFORE_INSERT, keyspace, id, value);
+	/**
+	 * Create new {@link BeforeInsertEvent}.
+	 * 
+	 * @param id
+	 * @param keySpace
+	 * @param type
+	 * @param value
+	 * @return
+	 */
+	public static <T> BeforeInsertEvent<T> beforeInsert(Serializable id, String keySpace, Class<? extends T> type, T value) {
+		return new BeforeInsertEvent<T>(id, keySpace, type, value);
 	}
 
-	public static InsertEvent afterInsert(Object source, String keyspace, Serializable id, Object value) {
-		return new InsertEvent(source, Type.AFTER_INSERT, keyspace, id, value);
+	/**
+	 * Create new {@link AfterInsertEvent}.
+	 * 
+	 * @param id
+	 * @param keySpace
+	 * @param type
+	 * @param value
+	 * @return
+	 */
+	public static <T> AfterInsertEvent<T> afterInsert(Serializable id, String keySpace, Class<? extends T> type, T value) {
+		return new AfterInsertEvent<T>(id, keySpace, type, value);
 	}
 
-	public static UpdateEvent beforeUpdate(Object source, String keyspace, Serializable id, Object value) {
-		return new UpdateEvent(source, Type.BEFORE_UPDATE, keyspace, id, value);
+	/**
+	 * Create new {@link BeforeUpdateEvent}.
+	 * 
+	 * @param id
+	 * @param keySpace
+	 * @param type
+	 * @param value
+	 * @return
+	 */
+	public static <T> BeforeUpdateEvent<T> beforeUpdate(Serializable id, String keySpace, Class<? extends T> type, T value) {
+		return new BeforeUpdateEvent<T>(id, keySpace, type, value);
 	}
 
-	public static UpdateEvent afterUpdate(Object source, String keyspace, Serializable id, Object value) {
-		return new UpdateEvent(source, Type.AFTER_UPDATE, keyspace, id, value);
+	/**
+	 * Create new {@link AfterUpdateEvent}.
+	 * 
+	 * @param id
+	 * @param keySpace
+	 * @param type
+	 * @param actualValue
+	 * @param previousValue
+	 * @return
+	 */
+	public static <T> AfterUpdateEvent<T> afterUpdate(Serializable id, String keySpace, Class<? extends T> type,
+			T actualValue, Object previousValue) {
+		return new AfterUpdateEvent<T>(id, keySpace, type, actualValue, previousValue);
 	}
 
-	public static DropKeyspaceEvent beforeDelete(Object source, String keyspace) {
-		return new DropKeyspaceEvent(source, Type.BEFORE_DELETE, keyspace);
+	/**
+	 * Create new {@link BeforeDropKeySpaceEvent}.
+	 * 
+	 * @param keySpace
+	 * @param type
+	 * @return
+	 */
+	public static <T> BeforeDropKeySpaceEvent<T> beforeDropKeySpace(String keySpace, Class<? extends T> type) {
+		return new BeforeDropKeySpaceEvent<T>(keySpace, type);
 	}
 
-	public static DeleteEvent beforeDelete(Object source, String keyspace, Serializable id) {
-		return beforeDelete(source, keyspace, id, null);
+	/**
+	 * Create new {@link AfterDropKeySpaceEvent}.
+	 * 
+	 * @param keySpace
+	 * @param type
+	 * @return
+	 */
+	public static <T> AfterDropKeySpaceEvent<T> afterDropKeySpace(String keySpace, Class<? extends T> type) {
+		return new AfterDropKeySpaceEvent<T>(keySpace, type);
 	}
 
-	public static DeleteEvent beforeDelete(Object source, String keyspace, Serializable id, Object value) {
-		return new DeleteEvent(source, Type.BEFORE_DELETE, keyspace, id, value);
+	/**
+	 * Create new {@link BeforeDeleteEvent}.
+	 * 
+	 * @param id
+	 * @param keySpace
+	 * @param type
+	 * @return
+	 */
+	public static <T> BeforeDeleteEvent<T> beforeDelete(Serializable id, String keySpace, Class<? extends T> type) {
+		return new BeforeDeleteEvent<T>(id, keySpace, type);
 	}
 
-	public static DropKeyspaceEvent afterDelete(Object source, String keyspace) {
-		return new DropKeyspaceEvent(source, Type.AFTER_DELETE, keyspace);
+	/**
+	 * Create new {@link AfterDeleteEvent}.
+	 * 
+	 * @param id
+	 * @param keySpace
+	 * @param type
+	 * @param value
+	 * @return
+	 */
+	public static <T> AfterDeleteEvent<T> afterDelete(Serializable id, String keySpace, Class<? extends T> type, T value) {
+		return new AfterDeleteEvent<T>(id, keySpace, type, value);
 	}
 
-	public static DeleteEvent afterDelete(Object source, String keyspace, Serializable id, Object value) {
-		return new DeleteEvent(source, Type.AFTER_DELETE, keyspace, id, value);
-	}
+	/**
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	abstract static class KeyBasedEvent<T> extends KeyValueEvent<T> {
 
-	public static class InsertEvent extends KeyValueEvent {
+		private Serializable key;
+		private Class<? extends T> type;
 
-		private static final long serialVersionUID = -1;
+		protected KeyBasedEvent(Serializable key, String keySpace, Class<? extends T> type) {
 
-		InsertEvent(Object source, Type type, String keyspace, Serializable id, Object value) {
-			super(source, type, keyspace, id, value);
+			super(type, keySpace);
+			this.key = key;
+		}
+
+		public Serializable getKey() {
+			return key;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.EventObject#getSource()
+		 */
+		@Override
+		public Serializable getSource() {
+			return getKey();
+		}
+
+		/**
+		 * Get the type of the element the {@link KeyValueEvent} refers to.
+		 * 
+		 * @return
+		 */
+		public Class<? extends T> getType() {
+			return type;
 		}
 	}
 
-	public static class UpdateEvent extends KeyValueEvent {
+	/**
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	abstract static class KeyBasedEventWithPayload<T> extends KeyBasedEvent<T> {
 
-		private static final long serialVersionUID = -1;
+		private final T payload;
 
-		UpdateEvent(Object source, Type type, String keyspace, Serializable id, Object value) {
-			super(source, type, keyspace, id, value);
+		public KeyBasedEventWithPayload(Serializable key, String keySpace, Class<? extends T> type, T payload) {
+			super(key, keySpace, type);
+			this.payload = payload;
+		}
+
+		/**
+		 * Get the value of the element the {@link KeyValueEvent} refers to. Can be {@literal null}.
+		 * 
+		 * @return
+		 */
+		public T getPayload() {
+			return payload;
 		}
 	}
 
-	public static class DeleteEvent extends KeyValueEvent {
+	/**
+	 * {@link KeyValueEvent} raised before loading an object by its {@literal key}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class BeforeGetEvent<T> extends KeyBasedEvent<T> {
 
-		private static final long serialVersionUID = -1;
-
-		DeleteEvent(Object source, Type type, String keyspace, Serializable id, Object value) {
-			super(source, type, keyspace, id, value);
-		}
-	}
-
-	public static class DropKeyspaceEvent extends DeleteEvent {
-
-		private static final long serialVersionUID = -1;
-
-		DropKeyspaceEvent(Object source, Type type, String keyspace) {
-			super(source, type, keyspace, null, null);
-		}
-	}
-
-	public static class GetEvent extends KeyValueEvent {
-
-		private static final long serialVersionUID = -1;
-
-		protected GetEvent(Object source, Type type, String keyspace,
-				Serializable id, Object value) {
-			super(source, type, keyspace, id, value);
+		protected BeforeGetEvent(Serializable key, String keySpace, Class<T> type) {
+			super(key, keySpace, type);
 		}
 
 	}
 
+	/**
+	 * {@link KeyValueEvent} after loading an object by its {@literal key}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class AfterGetEvent<T> extends KeyBasedEventWithPayload<T> {
+
+		protected AfterGetEvent(Serializable key, String keyspace, Class<T> type, T payload) {
+			super(key, keyspace, type, payload);
+		}
+
+	}
+
+	/**
+	 * {@link KeyValueEvent} before inserting an object by with a given {@literal key}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class BeforeInsertEvent<T> extends KeyBasedEventWithPayload<T> {
+
+		public BeforeInsertEvent(Serializable key, String keySpace, Class<? extends T> type, T payload) {
+			super(key, keySpace, type, payload);
+
+		}
+	}
+
+	/**
+	 * {@link KeyValueEvent} after inserting an object by with a given {@literal key}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class AfterInsertEvent<T> extends KeyBasedEventWithPayload<T> {
+
+		public AfterInsertEvent(Serializable key, String keySpace, Class<? extends T> type, T payload) {
+			super(key, keySpace, type, payload);
+		}
+	}
+
+	/**
+	 * {@link KeyValueEvent} before updating an object by with a given {@literal key}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class BeforeUpdateEvent<T> extends KeyBasedEventWithPayload<T> {
+
+		public BeforeUpdateEvent(Serializable key, String keySpace, Class<? extends T> type, T payload) {
+			super(key, keySpace, type, payload);
+		}
+	}
+
+	/**
+	 * {@link KeyValueEvent} after updating an object by with a given {@literal key}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class AfterUpdateEvent<T> extends KeyBasedEventWithPayload<T> {
+
+		private final Object existing;
+
+		public AfterUpdateEvent(Serializable key, String keySpace, Class<? extends T> type, T payload, Object existing) {
+			super(key, keySpace, type, payload);
+			this.existing = existing;
+		}
+
+		/**
+		 * Get the value before update. Can be {@literal null}.
+		 * 
+		 * @return
+		 */
+		public Object before() {
+			return existing;
+		}
+
+		/**
+		 * Get the current value.
+		 * 
+		 * @return
+		 */
+		public T after() {
+			return getPayload();
+		}
+	}
+
+	/**
+	 * {@link KeyValueEvent} before removing an object by with a given {@literal key}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class BeforeDeleteEvent<T> extends KeyBasedEvent<T> {
+
+		public BeforeDeleteEvent(Serializable key, String keySpace, Class<? extends T> type) {
+			super(key, keySpace, type);
+		}
+	}
+
+	/**
+	 * {@link KeyValueEvent} after removing an object by with a given {@literal key}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class AfterDeleteEvent<T> extends KeyBasedEventWithPayload<T> {
+
+		public AfterDeleteEvent(Serializable key, String keySpace, Class<? extends T> type, T payload) {
+			super(key, keySpace, type, payload);
+		}
+	}
+
+	/**
+	 * {@link KeyValueEvent} before removing all elements in a given {@literal keySpace}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class BeforeDropKeySpaceEvent<T> extends KeyValueEvent<T> {
+
+		public BeforeDropKeySpaceEvent(String keySpace, Class<? extends T> type) {
+			super(type, keySpace);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public Class<T> getSource() {
+			return (Class<T>) super.getSource();
+		}
+
+	}
+
+	/**
+	 * {@link KeyValueEvent} after removing all elements in a given {@literal keySpace}.
+	 * 
+	 * @author Christoph Strobl
+	 * @param <T>
+	 */
+	@SuppressWarnings("serial")
+	public static class AfterDropKeySpaceEvent<T> extends KeyValueEvent<T> {
+
+		public AfterDropKeySpaceEvent(String keySpace, Class<? extends T> type) {
+			super(type, keySpace);
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public Class<T> getSource() {
+			return (Class<T>) super.getSource();
+		}
+	}
 }


### PR DESCRIPTION
- Favor dedicated types over event type enum.
- Allow events to be generically typed.
- Favor ApplicationEventPublisherAware over ApplicationContextAware.
- By default publish all events - allow user to opt out.