### PR TITLE
DATAKV-115 - Make derived finder execution thread-safe.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAKV-115-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/core/SpelCriteria.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SpelCriteria.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.keyvalue.core;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * {@link SpelCriteria} allows to pass on a {@link SpelExpression} and {@link EvaluationContext} to the actual query
+ * processor. This decouples the {@link SpelExpression} from the context it is used in.
+ * 
+ * @author Christoph Strobl
+ */
+public class SpelCriteria {
+
+	private final SpelExpression expression;
+	private final EvaluationContext context;
+
+	/**
+	 * Creates new {@link SpelCriteria}.
+	 * 
+	 * @param expression must not be {@literal null}.
+	 * @param context can be {@literal null} and will be defaulted to {@link StandardEvaluationContext}.
+	 */
+	public SpelCriteria(SpelExpression expression, EvaluationContext context) {
+
+		this.expression = expression;
+		this.context = context == null ? new StandardEvaluationContext() : context;
+	}
+
+	/**
+	 * @return never {@literal null}.
+	 */
+	public EvaluationContext getContext() {
+		return context;
+	}
+
+	/**
+	 * @return never {@literal null}.
+	 */
+	public SpelExpression getExpression() {
+		return expression;
+	}
+
+}

--- a/src/main/java/org/springframework/data/keyvalue/core/SpelCriteriaAccessor.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SpelCriteriaAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.data.keyvalue.core;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.util.Assert;
 
 /**
@@ -26,7 +27,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Oliver Gierke
  */
-class SpelCriteriaAccessor implements CriteriaAccessor<SpelExpression> {
+class SpelCriteriaAccessor implements CriteriaAccessor<SpelCriteria> {
 
 	private final SpelExpressionParser parser;
 
@@ -40,20 +41,25 @@ class SpelCriteriaAccessor implements CriteriaAccessor<SpelExpression> {
 	}
 
 	@Override
-	public SpelExpression resolve(KeyValueQuery<?> query) {
+	public SpelCriteria resolve(KeyValueQuery<?> query) {
 
 		if (query.getCritieria() == null) {
 			return null;
 		}
 
 		if (query.getCritieria() instanceof SpelExpression) {
-			return (SpelExpression) query.getCritieria();
+			return new SpelCriteria((SpelExpression) query.getCritieria(), new StandardEvaluationContext());
 		}
 
 		if (query.getCritieria() instanceof String) {
-			return parser.parseRaw((String) query.getCritieria());
+			return new SpelCriteria(parser.parseRaw((String) query.getCritieria()), new StandardEvaluationContext());
+		}
+
+		if (query.getCritieria() instanceof SpelCriteria) {
+			return (SpelCriteria) query.getCritieria();
 		}
 
 		throw new IllegalArgumentException("Cannot create SpelCriteria for " + query.getCritieria());
 	}
+
 }

--- a/src/test/java/org/springframework/data/keyvalue/core/SpelQueryEngineUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/SpelQueryEngineUnitTests.java
@@ -16,7 +16,6 @@
 package org.springframework.data.keyvalue.core;
 
 import static org.hamcrest.Matchers.*;
-import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
@@ -33,14 +32,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.data.keyvalue.repository.query.SpelQueryCreator;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.parser.PartTree;
-import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
@@ -77,8 +74,8 @@ public class SpelQueryEngineUnitTests {
 
 		doReturn(people).when(adapter).getAllOf(anyString());
 
-		assertThat((Collection<Person>) engine.execute(createQueryForMethodWithArgs("findByFirstname", "bob"), null, -1, -1,
-				anyString()), contains(BOB_WITH_FIRSTNAME));
+		assertThat((Collection<Person>) engine.execute(createQueryForMethodWithArgs("findByFirstname", "bob"), null, -1,
+				-1, anyString()), contains(BOB_WITH_FIRSTNAME));
 	}
 
 	/**
@@ -92,7 +89,7 @@ public class SpelQueryEngineUnitTests {
 		assertThat(engine.count(createQueryForMethodWithArgs("findByFirstname", "bob"), anyString()), is(1L));
 	}
 
-	private static SpelExpression createQueryForMethodWithArgs(String methodName, Object... args) throws Exception {
+	private static SpelCriteria createQueryForMethodWithArgs(String methodName, Object... args) throws Exception {
 
 		List<Class<?>> types = new ArrayList<Class<?>>(args.length);
 
@@ -105,13 +102,10 @@ public class SpelQueryEngineUnitTests {
 		doReturn(method.getReturnType()).when(metadata).getReturnedDomainClass(method);
 
 		PartTree partTree = new PartTree(method.getName(), method.getReturnType());
-		SpelQueryCreator creator = new SpelQueryCreator(partTree, new ParametersParameterAccessor(
-				new QueryMethod(method, metadata, new SpelAwareProxyProjectionFactory()).getParameters(), args));
+		SpelQueryCreator creator = new SpelQueryCreator(partTree, new ParametersParameterAccessor(new QueryMethod(method,
+				metadata, new SpelAwareProxyProjectionFactory()).getParameters(), args));
 
-		KeyValueQuery<SpelExpression> query = creator.createQuery();
-		query.getCritieria().setEvaluationContext(new StandardEvaluationContext(args));
-
-		return query.getCritieria();
+		return new SpelCriteria(creator.createQuery().getCritieria(), new StandardEvaluationContext(args));
 	}
 
 	static interface PersonRepository {

--- a/src/test/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQueryUnitTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.keyvalue.repository.query;
+
+import static org.hamcrest.core.IsNot.*;
+import static org.hamcrest.core.IsSame.*;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.keyvalue.Person;
+import org.springframework.data.keyvalue.core.KeyValueOperations;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.query.DefaultEvaluationContextProvider;
+import org.springframework.data.repository.query.QueryMethod;
+
+/**
+ * @author Christoph Strobl
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class KeyValuePartTreeQueryUnitTests {
+
+	@Mock KeyValueOperations kvOpsMock;
+	@Mock RepositoryMetadata metadataMock;
+	@Mock ProjectionFactory projectionFactoryMock;
+
+	/**
+	 * @see DATAKV-115
+	 */
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void spelExpressionAndContextShouldNotBeReused() throws NoSuchMethodException, SecurityException {
+
+		when(metadataMock.getDomainType()).thenReturn((Class) Person.class);
+		when(metadataMock.getReturnedDomainClass(any(Method.class))).thenReturn((Class) Person.class);
+
+		QueryMethod qm = new QueryMethod(Repo.class.getMethod("findByFirstname", String.class), metadataMock,
+				projectionFactoryMock);
+
+		KeyValuePartTreeQuery query = new KeyValuePartTreeQuery(qm, DefaultEvaluationContextProvider.INSTANCE, kvOpsMock,
+				SpelQueryCreator.class);
+
+		Object[] args = new Object[] { "foo" };
+
+		assertThat(query.prepareQuery(args).getCritieria(), not(sameInstance(query.prepareQuery(args).getCritieria())));
+	}
+
+	static interface Repo {
+
+		List<Person> findByFirstname(String firstname);
+	}
+}


### PR DESCRIPTION
We now make sure separate `SpelExpression` and `EvaluationContext` for each and every derived finder execution to assert the context cannot be accidentally overridden.