### PR TITLE
DATAKV-112, 	DATAKV-117 - Make caching repository queries more explicit and pass on type information.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAKV-112-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/core/AbstractKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/AbstractKeyValueAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/keyvalue/core/AbstractKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/AbstractKeyValueAdapter.java
@@ -59,6 +59,33 @@ public abstract class AbstractKeyValueAdapter implements KeyValueAdapter {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#get(java.io.Serializable, java.io.Serializable, java.lang.Class)
+	 */
+	@Override
+	public <T> T get(Serializable id, Serializable keyspace, Class<T> type) {
+		return (T) get(id, keyspace);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#get(java.io.Serializable, java.io.Serializable, java.lang.Class)
+	 */
+	@Override
+	public <T> T delete(Serializable id, Serializable keyspace, Class<T> type) {
+		return (T) delete(id, keyspace);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#get(java.io.Serializable, java.io.Serializable, java.lang.Class)
+	 */
+	@Override
+	public <T> Iterable<T> find(KeyValueQuery<?> query, Serializable keyspace, Class<T> type) {
+		return (Iterable<T>) engine.execute(query, keyspace, type);
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#find(org.springframework.data.keyvalue.core.query.KeyValueQuery, java.io.Serializable)
 	 */
 	@Override

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
@@ -59,6 +59,15 @@ public interface KeyValueAdapter extends DisposableBean {
 	Object get(Serializable id, Serializable keyspace);
 
 	/**
+	 * @param id
+	 * @param keyspace
+	 * @param type
+	 * @return
+	 * @since 1.1
+	 */
+	<T> T get(Serializable id, Serializable keyspace, Class<T> type);
+
+	/**
 	 * Delete and return the obect with given type and id.
 	 * 
 	 * @param id must not be {@literal null}.
@@ -66,6 +75,15 @@ public interface KeyValueAdapter extends DisposableBean {
 	 * @return {@literal null} if object could not be found
 	 */
 	Object delete(Serializable id, Serializable keyspace);
+
+	/**
+	 * @param id
+	 * @param keyspace
+	 * @param type
+	 * @return
+	 * @since 1.1
+	 */
+	<T> T delete(Serializable id, Serializable keyspace, Class<T> type);
 
 	/**
 	 * Get all elements for given keyspace.
@@ -103,6 +121,15 @@ public interface KeyValueAdapter extends DisposableBean {
 	 * @return empty {@link Collection} if no match found.
 	 */
 	Iterable<?> find(KeyValueQuery<?> query, Serializable keyspace);
+
+	/**
+	 * @param query
+	 * @param keyspace
+	 * @param type
+	 * @return
+	 * @since 1.1
+	 */
+	<T> Iterable<T> find(KeyValueQuery<?> query, Serializable keyspace, Class<T> type);
 
 	/**
 	 * Count number of objects within {@literal keyspace}.

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ public interface KeyValueAdapter extends DisposableBean {
 	Iterable<?> getAllOf(Serializable keyspace);
 
 	/**
-	 * Returns a {@link KeyValueIterator} that iterates over all entries.
+	 * Returns a {@link CloseableIterator} that iterates over all entries.
 	 * 
 	 * @param keyspace
 	 * @return

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
@@ -271,7 +271,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 			@Override
 			public T doInKeyValue(KeyValueAdapter adapter) {
 
-				Object result = adapter.get(id, keyspace);
+				Object result = adapter.get(id, keyspace, type);
 
 				if (result == null || typeCheck(type, result)) {
 					return (T) result;
@@ -342,10 +342,9 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 
 		T result = execute(new KeyValueCallback<T>() {
 
-			@SuppressWarnings("unchecked")
 			@Override
 			public T doInKeyValue(KeyValueAdapter adapter) {
-				return (T) adapter.delete(id, keyspace);
+				return (T) adapter.delete(id, keyspace, type);
 			}
 		});
 
@@ -394,7 +393,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 			@Override
 			public Iterable<T> doInKeyValue(KeyValueAdapter adapter) {
 
-				Iterable<?> result = adapter.find(query, resolveKeySpace(type));
+				Iterable<?> result = adapter.find(query, resolveKeySpace(type), type);
 				if (result == null) {
 					return Collections.emptySet();
 				}

--- a/src/main/java/org/springframework/data/keyvalue/core/QueryEngine.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/QueryEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/keyvalue/core/QueryEngine.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/QueryEngine.java
@@ -63,6 +63,21 @@ public abstract class QueryEngine<ADAPTER extends KeyValueAdapter, CRITERIA, SOR
 	 * @param keyspace
 	 * @return
 	 */
+	public <T> Collection<T> execute(KeyValueQuery<?> query, Serializable keyspace, Class<T> type) {
+
+		CRITERIA criteria = this.criteriaAccessor != null ? this.criteriaAccessor.resolve(query) : null;
+		SORT sort = this.sortAccessor != null ? this.sortAccessor.resolve(query) : null;
+
+		return execute(criteria, sort, query.getOffset(), query.getRows(), keyspace, type);
+	}
+
+	/**
+	 * Extract query attributes and delegate to concrete execution.
+	 * 
+	 * @param query
+	 * @param keyspace
+	 * @return
+	 */
 	public long count(KeyValueQuery<?> query, Serializable keyspace) {
 
 		CRITERIA criteria = this.criteriaAccessor != null ? this.criteriaAccessor.resolve(query) : null;
@@ -78,6 +93,21 @@ public abstract class QueryEngine<ADAPTER extends KeyValueAdapter, CRITERIA, SOR
 	 * @return
 	 */
 	public abstract Collection<?> execute(CRITERIA criteria, SORT sort, int offset, int rows, Serializable keyspace);
+
+	/**
+	 * @param criteria
+	 * @param sort
+	 * @param offset
+	 * @param rows
+	 * @param keyspace
+	 * @param type
+	 * @return
+	 * @since 1.1
+	 */
+	public <T> Collection<T> execute(CRITERIA criteria, SORT sort, int offset, int rows, Serializable keyspace,
+			Class<T> type) {
+		return (Collection<T>) execute(criteria, sort, offset, rows, keyspace);
+	}
 
 	/**
 	 * @param criteria

--- a/src/main/java/org/springframework/data/keyvalue/repository/config/QueryCreatorType.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/config/QueryCreatorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.data.keyvalue.repository.query.KeyValuePartTreeQuery;
+import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 
 /**
  * Annotation to customize the query creator type to be used for a specific store.
  * 
  * @author Oliver Gierke
+ * @author Christoph Strobl
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
@@ -34,4 +37,12 @@ import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 public @interface QueryCreatorType {
 
 	Class<? extends AbstractQueryCreator<?, ?>> value();
+
+	/**
+	 * The {@link RepositoryQuery} type to be created by the {@link QueryCreatorType#value()}.
+	 * 
+	 * @return
+	 * @since 1.1
+	 */
+	Class<? extends RepositoryQuery> repositoryQueryType() default KeyValuePartTreeQuery.class;
 }

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/CachingKeyValuePartTreeQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/CachingKeyValuePartTreeQuery.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.keyvalue.repository.query;
+
+import org.springframework.data.keyvalue.core.KeyValueOperations;
+import org.springframework.data.keyvalue.core.query.KeyValueQuery;
+import org.springframework.data.repository.query.EvaluationContextProvider;
+import org.springframework.data.repository.query.QueryMethod;
+import org.springframework.data.repository.query.parser.AbstractQueryCreator;
+import org.springframework.data.repository.query.parser.PartTree;
+
+/**
+ * {@link KeyValuePartTreeQuery} implementation deriving queries from {@link PartTree} using a predefined
+ * {@link AbstractQueryCreator} that caches the once created query.
+ * 
+ * @author Christoph Strobl
+ * @since 1.1
+ */
+public class CachingKeyValuePartTreeQuery extends KeyValuePartTreeQuery {
+
+	private KeyValueQuery<?> cachedQuery;
+
+	public CachingKeyValuePartTreeQuery(QueryMethod queryMethod, EvaluationContextProvider evaluationContextProvider,
+			KeyValueOperations keyValueOperations, Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
+		super(queryMethod, evaluationContextProvider, keyValueOperations, queryCreator);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.keyvalue.repository.query.KeyValuePartTreeQuery#prepareQuery(java.lang.Object[])
+	 */
+	protected KeyValueQuery<?> prepareQuery(Object[] parameters) {
+
+		if (cachedQuery == null) {
+			cachedQuery = super.prepareQuery(parameters);
+		}
+
+		return prepareQuery(cachedQuery, parameters);
+	}
+}

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactoryBean.java
@@ -24,6 +24,7 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
+import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.util.Assert;
 
@@ -33,11 +34,12 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Oliver Gierke
  */
-public class KeyValueRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable> extends
-		RepositoryFactoryBeanSupport<T, S, ID> {
+public class KeyValueRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
+		extends RepositoryFactoryBeanSupport<T, S, ID> {
 
 	private KeyValueOperations operations;
 	private Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
+	private Class<? extends RepositoryQuery> repositoryQueryType;
 
 	/**
 	 * Configures the {@link KeyValueOperations} to be used for the repositories.
@@ -72,27 +74,42 @@ public class KeyValueRepositoryFactoryBean<T extends Repository<S, ID>, S, ID ex
 		this.queryCreator = queryCreator;
 	}
 
+	/**
+	 * Configures the {@link RepositoryQuery} type to be created.
+	 *
+	 * @param repositoryQueryType must not be {@literal null}.
+	 * @since 1.1
+	 */
+	public void setQueryType(Class<? extends RepositoryQuery> repositoryQueryType) {
+
+		Assert.notNull(queryCreator, "Query creator type must not be null!");
+
+		this.repositoryQueryType = repositoryQueryType;
+
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport#createRepositoryFactory()
 	 */
 	@Override
 	protected final RepositoryFactorySupport createRepositoryFactory() {
-		return createRepositoryFactory(operations, queryCreator);
+		return createRepositoryFactory(operations, queryCreator, repositoryQueryType);
 	}
 
 	/**
 	 * Create the repository factory to be used to create repositories.
-	 * 
+	 *
 	 * @param operations will never be {@literal null}.
 	 * @param queryCreator will never be {@literal null}.
+	 * @param repositoryQueryType will never be {@literal null}.
 	 * @return must not be {@literal null}.
 	 * @since 1.1
 	 */
 	protected KeyValueRepositoryFactory createRepositoryFactory(KeyValueOperations operations,
-			Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
+			Class<? extends AbstractQueryCreator<?, ?>> queryCreator, Class<? extends RepositoryQuery> repositoryQueryType) {
 
-		return new KeyValueRepositoryFactory(operations, queryCreator);
+		return new KeyValueRepositoryFactory(operations, queryCreator, repositoryQueryType);
 	}
 
 	/*
@@ -104,6 +121,7 @@ public class KeyValueRepositoryFactoryBean<T extends Repository<S, ID>, S, ID ex
 
 		Assert.notNull(operations, "KeyValueOperations must not be null!");
 		Assert.notNull(queryCreator, "Query creator type must not be null!");
+		Assert.notNull(repositoryQueryType, "RepositoryQueryType type type must not be null!");
 
 		super.afterPropertiesSet();
 	}

--- a/src/main/java/org/springframework/data/map/repository/config/EnableMapRepositories.java
+++ b/src/main/java/org/springframework/data/map/repository/config/EnableMapRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.keyvalue.core.KeyValueOperations;
 import org.springframework.data.keyvalue.core.KeyValueTemplate;
 import org.springframework.data.keyvalue.repository.config.QueryCreatorType;
+import org.springframework.data.keyvalue.repository.query.CachingKeyValuePartTreeQuery;
 import org.springframework.data.keyvalue.repository.query.SpelQueryCreator;
 import org.springframework.data.keyvalue.repository.support.KeyValueRepositoryFactoryBean;
 import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
@@ -49,7 +50,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy.Key;
 @Documented
 @Inherited
 @Import(MapRepositoriesRegistrar.class)
-@QueryCreatorType(SpelQueryCreator.class)
+@QueryCreatorType(value = SpelQueryCreator.class, repositoryQueryType = CachingKeyValuePartTreeQuery.class)
 public @interface EnableMapRepositories {
 
 	/**

--- a/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
@@ -212,7 +212,7 @@ public class KeyValueTemplateUnitTests {
 
 		template.findById("1", Foo.class);
 
-		verify(adapterMock, times(1)).get("1", Foo.class.getName());
+		verify(adapterMock, times(1)).get("1", Foo.class.getName(), Foo.class);
 	}
 
 	/**
@@ -250,7 +250,7 @@ public class KeyValueTemplateUnitTests {
 
 		template.find(STRING_QUERY, Foo.class);
 
-		verify(adapterMock, times(1)).find(STRING_QUERY, Foo.class.getName());
+		verify(adapterMock, times(1)).find(STRING_QUERY, Foo.class.getName(), Foo.class);
 	}
 
 	/**
@@ -264,7 +264,7 @@ public class KeyValueTemplateUnitTests {
 
 		template.findInRange(1, 5, Foo.class);
 
-		verify(adapterMock, times(1)).find(captor.capture(), eq(Foo.class.getName()));
+		verify(adapterMock, times(1)).find(captor.capture(), eq(Foo.class.getName()), eq(Foo.class));
 		assertThat(captor.getValue().getOffset(), is(1));
 		assertThat(captor.getValue().getRows(), is(5));
 		assertThat(captor.getValue().getCritieria(), nullValue());
@@ -327,7 +327,7 @@ public class KeyValueTemplateUnitTests {
 
 		template.delete("1", Foo.class);
 
-		verify(adapterMock, times(1)).delete("1", Foo.class.getName());
+		verify(adapterMock, times(1)).delete("1", Foo.class.getName(), Foo.class);
 	}
 
 	/**
@@ -341,7 +341,7 @@ public class KeyValueTemplateUnitTests {
 
 		template.delete(source);
 
-		verify(adapterMock, times(1)).delete("some-id", ClassWithStringId.class.getName());
+		verify(adapterMock, times(1)).delete("some-id", ClassWithStringId.class.getName(), ClassWithStringId.class);
 	}
 
 	/**
@@ -616,7 +616,7 @@ public class KeyValueTemplateUnitTests {
 	public void shouldPublishAfterDeleteEventCorrectly() {
 
 		setEventsToPublish(AfterDeleteEvent.class);
-		when(adapterMock.delete(eq("1"), eq(FOO_ONE.getClass().getName()))).thenReturn(FOO_ONE);
+		when(adapterMock.delete(eq("1"), eq(FOO_ONE.getClass().getName()), eq(Foo.class))).thenReturn(FOO_ONE);
 
 		template.delete("1", FOO_ONE.getClass());
 
@@ -663,7 +663,7 @@ public class KeyValueTemplateUnitTests {
 
 		setEventsToPublish(AfterGetEvent.class);
 
-		when(adapterMock.get(eq("1"), eq(FOO_ONE.getClass().getName()))).thenReturn(FOO_ONE);
+		when(adapterMock.get(eq("1"), eq(FOO_ONE.getClass().getName()), eq(Foo.class))).thenReturn(FOO_ONE);
 
 		template.findById("1", FOO_ONE.getClass());
 

--- a/src/test/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactoryBeanUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactoryBeanUnitTests.java
@@ -26,7 +26,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.data.keyvalue.core.KeyValueOperations;
+import org.springframework.data.keyvalue.repository.query.KeyValuePartTreeQuery;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 
 /**
@@ -95,6 +97,7 @@ public class KeyValueRepositoryFactoryBeanUnitTests {
 
 	/**
 	 * @see DATAKV-123
+	 * @see DATAKV-112
 	 */
 	@Test
 	@SuppressWarnings("unchecked")
@@ -102,9 +105,12 @@ public class KeyValueRepositoryFactoryBeanUnitTests {
 
 		Class<? extends AbstractQueryCreator<?, ?>> creatorType = (Class<? extends AbstractQueryCreator<?, ?>>) mock(
 				AbstractQueryCreator.class).getClass();
+		Class<? extends RepositoryQuery> queryType = (Class<? extends RepositoryQuery>) mock(KeyValuePartTreeQuery.class)
+				.getClass();
 
 		factoryBean.setQueryCreator(creatorType);
 		factoryBean.setKeyValueOperations(mock(KeyValueOperations.class));
+		factoryBean.setQueryType(queryType);
 
 		exception.expect(IllegalArgumentException.class);
 		exception.expectMessage("Repository interface");
@@ -121,10 +127,21 @@ public class KeyValueRepositoryFactoryBeanUnitTests {
 
 		Class<? extends AbstractQueryCreator<?, ?>> creatorType = (Class<? extends AbstractQueryCreator<?, ?>>) mock(
 				AbstractQueryCreator.class).getClass();
+		Class<? extends RepositoryQuery> queryType = (Class<? extends RepositoryQuery>) mock(KeyValuePartTreeQuery.class)
+				.getClass();
 
 		factoryBean.setQueryCreator(creatorType);
 		factoryBean.setKeyValueOperations(mock(KeyValueOperations.class));
+		factoryBean.setQueryType(queryType);
 
 		assertThat(factoryBean.createRepositoryFactory(), is(notNullValue()));
+	}
+
+	/**
+	 * @see DATAKV-112
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void rejectsNullQueryType() {
+		factoryBean.setQueryType(null);
 	}
 }


### PR DESCRIPTION
**DATAKV-112**
We introduced an explicit `CachingKeyValuePartTreeQuery` and allow setting the genernal repository query strategy via `QueryCreatorType`.
By default queries will not be cached.

**DATAKV-117**
We now pass on type information to KV Adapter.

----

required by: spring-projects/spring-data-redis#156