### PR TITLE
DATAKV-142 - Consider PartTree.isLimiting() and PartTree.getMaxResults() when creating queries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>1.2.0.BUILD-SNAPSHOT</version>
+	<version>1.2.0.DATAKV-142-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
@@ -150,7 +150,13 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 		Sort sort = accessor.getSort();
 
 		query.setOffset(pageable == null ? -1 : pageable.getOffset());
-		query.setRows(pageable == null ? -1 : pageable.getPageSize());
+
+		if (pageable != null) {
+			query.setRows(pageable.getPageSize());
+		} else if (instance.getRows() >= 0) {
+			query.setRows(instance.getRows());
+		}
+
 		query.setSort(sort == null ? instance.getSort() : sort);
 
 		return query;
@@ -175,7 +181,12 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 
 		Constructor<? extends AbstractQueryCreator<?, ?>> constructor = (Constructor<? extends AbstractQueryCreator<?, ?>>) ClassUtils
 				.getConstructorIfAvailable(queryCreator, PartTree.class, ParameterAccessor.class);
-		return (KeyValueQuery<?>) BeanUtils.instantiateClass(constructor, tree, accessor).createQuery();
+		KeyValueQuery<?> query = (KeyValueQuery<?>) BeanUtils.instantiateClass(constructor, tree, accessor).createQuery();
+
+		if (tree.isLimiting()) {
+			query.setRows(tree.getMaxResults());
+		}
+		return query;
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQueryUnitTests.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.data.keyvalue.repository.query;
 
+import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsNot.*;
+import static org.hamcrest.core.IsNull.*;
 import static org.hamcrest.core.IsSame.*;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
@@ -24,12 +26,17 @@ import static org.mockito.Mockito.*;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.keyvalue.Person;
 import org.springframework.data.keyvalue.core.KeyValueOperations;
+import org.springframework.data.keyvalue.core.SpelCriteria;
+import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.DefaultEvaluationContextProvider;
@@ -69,8 +76,81 @@ public class KeyValuePartTreeQueryUnitTests {
 		assertThat(first, not(sameInstance(second)));
 	}
 
+	/**
+	 * @see DATAKV-142
+	 */
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void shouldApplayPageableParameterToCollectionQuery() throws SecurityException, NoSuchMethodException {
+
+		when(metadataMock.getDomainType()).thenReturn((Class) Person.class);
+		when(metadataMock.getReturnedDomainClass(any(Method.class))).thenReturn((Class) Person.class);
+
+		QueryMethod qm = new QueryMethod(Repo.class.getMethod("findBy", Pageable.class), metadataMock,
+				projectionFactoryMock);
+
+		KeyValuePartTreeQuery partTreeQuery = new KeyValuePartTreeQuery(qm, DefaultEvaluationContextProvider.INSTANCE,
+				kvOpsMock, SpelQueryCreator.class);
+
+		KeyValueQuery<?> query = partTreeQuery.prepareQuery(new Object[] { new PageRequest(2, 3) });
+
+		assertThat(query.getOffset(), is(6));
+		assertThat(query.getRows(), is(3));
+	}
+
+	/**
+	 * @see DATAKV-142
+	 */
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void shouldApplyDerivedMaxResultsToQuery() throws SecurityException, NoSuchMethodException {
+
+		when(metadataMock.getDomainType()).thenReturn((Class) Person.class);
+		when(metadataMock.getReturnedDomainClass(any(Method.class))).thenReturn((Class) Person.class);
+
+		QueryMethod qm = new QueryMethod(Repo.class.getMethod("findTop3By"), metadataMock, projectionFactoryMock);
+
+		KeyValuePartTreeQuery partTreeQuery = new KeyValuePartTreeQuery(qm, DefaultEvaluationContextProvider.INSTANCE,
+				kvOpsMock, SpelQueryCreator.class);
+
+		KeyValueQuery<?> query = partTreeQuery.prepareQuery(new Object[] {});
+
+		assertThat(query.getRows(), is(3));
+	}
+
+	/**
+	 * @see DATAKV-142
+	 */
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void shouldApplyDerivedMaxResultsToQueryWithParameters() throws SecurityException, NoSuchMethodException {
+
+		when(metadataMock.getDomainType()).thenReturn((Class) Person.class);
+		when(metadataMock.getReturnedDomainClass(any(Method.class))).thenReturn((Class) Person.class);
+
+		QueryMethod qm = new QueryMethod(Repo.class.getMethod("findTop3ByFirstname", String.class), metadataMock,
+				projectionFactoryMock);
+
+		KeyValuePartTreeQuery partTreeQuery = new KeyValuePartTreeQuery(qm, DefaultEvaluationContextProvider.INSTANCE,
+				kvOpsMock, SpelQueryCreator.class);
+
+		KeyValueQuery<?> query = partTreeQuery.prepareQuery(new Object[] { "firstname" });
+
+		assertThat(query.getCritieria(), is(notNullValue()));
+		assertThat(query.getCritieria(), IsInstanceOf.instanceOf(SpelCriteria.class));
+		assertThat(((SpelCriteria) query.getCritieria()).getExpression().getExpressionString(),
+				is("#it?.firstname?.equals([0])"));
+		assertThat(query.getRows(), is(3));
+	}
+
 	static interface Repo {
 
 		List<Person> findByFirstname(String firstname);
+
+		List<Person> findBy(Pageable page);
+
+		List<Person> findTop3By();
+
+		List<Person> findTop3ByFirstname(String firstname);
 	}
 }


### PR DESCRIPTION
We now pick up result size limiting constraints from the query methods name. This allows usage of `findTopN` and `findFirst` keywords.