### PR TITLE
DATAKV-169 - Add support for IN keyword in derived queries. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAKV-169-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/asciidoc/key-value-repositories.adoc
+++ b/src/main/asciidoc/key-value-repositories.adoc
@@ -98,7 +98,7 @@ NOTE: The composed annotation needs to inherit `@Persistent`.
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE })
 static @interface CacheCentricAnnotation {
-  
+
   @KeySpace String cacheRegion() default "";
 }
 
@@ -106,7 +106,7 @@ static @interface CacheCentricAnnotation {
 class Customer {
   //...
 }
----- 
+----
 
 [[key-value.template-query]]
 == Querying
@@ -133,7 +133,7 @@ When used without further customization sorting is done using a `SpelPropertyCom
 [source, java]
 ----
 KeyValueQuery<String> query = new KeyValueQuery<String>("lastname == 'baratheon'");
-query.setSort(new Sort(DESC, "age"));
+query.setSort(Sort.by(DESC, "age"));
 List<Person> targaryens = template.find(query, Person.class);
 ----
 

--- a/src/main/java/org/springframework/data/keyvalue/core/AbstractKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/AbstractKeyValueAdapter.java
@@ -23,7 +23,7 @@ import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 /**
  * Base implementation of {@link KeyValueAdapter} holds {@link QueryEngine} to delegate {@literal find} and
  * {@literal count} execution to.
- * 
+ *
  * @author Christoph Strobl
  */
 public abstract class AbstractKeyValueAdapter implements KeyValueAdapter {
@@ -39,18 +39,18 @@ public abstract class AbstractKeyValueAdapter implements KeyValueAdapter {
 
 	/**
 	 * Creates new {@link AbstractKeyValueAdapter} with using the default query engine.
-	 * 
+	 *
 	 * @param engine will be defaulted to {@link SpelQueryEngine} if {@literal null}.
 	 */
 	protected AbstractKeyValueAdapter(QueryEngine<? extends KeyValueAdapter, ?, ?> engine) {
 
-		this.engine = engine != null ? engine : new SpelQueryEngine<KeyValueAdapter>();
+		this.engine = engine != null ? engine : new SpelQueryEngine<>();
 		this.engine.registerAdapter(this);
 	}
 
 	/**
 	 * Get the {@link QueryEngine} used.
-	 * 
+	 *
 	 * @return
 	 */
 	protected QueryEngine<? extends KeyValueAdapter, ?, ?> getQueryEngine() {

--- a/src/main/java/org/springframework/data/keyvalue/core/DefaultIdentifierGenerator.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/DefaultIdentifierGenerator.java
@@ -29,7 +29,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Default implementation of {@link IdentifierGenerator} to generate identifiers of types {@link UUID}, String,
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  */
@@ -37,7 +37,7 @@ enum DefaultIdentifierGenerator implements IdentifierGenerator {
 
 	INSTANCE;
 
-	private final AtomicReference<SecureRandom> secureRandom = new AtomicReference<SecureRandom>(null);
+	private final AtomicReference<SecureRandom> secureRandom = new AtomicReference<>(null);
 
 	/*
 	 * (non-Javadoc)

--- a/src/main/java/org/springframework/data/keyvalue/core/IterableConverter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/IterableConverter.java
@@ -22,9 +22,8 @@ import java.util.List;
 
 /**
  * Converter capable of transforming a given {@link Iterable} into a collection type.
- * 
+ *
  * @author Christoph Strobl
- * @param <T>
  */
 public final class IterableConverter {
 
@@ -32,7 +31,7 @@ public final class IterableConverter {
 
 	/**
 	 * Converts a given {@link Iterable} into a {@link List}
-	 * 
+	 *
 	 * @param source
 	 * @return {@link Collections#emptyList()} when source is {@literal null}.
 	 */
@@ -47,10 +46,10 @@ public final class IterableConverter {
 		}
 
 		if (source instanceof Collection) {
-			return new ArrayList<T>((Collection<T>) source);
+			return new ArrayList<>((Collection<T>) source);
 		}
 
-		List<T> result = new ArrayList<T>();
+		List<T> result = new ArrayList<>();
 		for (T value : source) {
 			result.add(value);
 		}

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
@@ -42,7 +42,7 @@ import org.springframework.util.ObjectUtils;
 
 /**
  * Basic implementation of {@link KeyValueOperations}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Thomas Darimont
@@ -64,7 +64,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 	/**
 	 * Create new {@link KeyValueTemplate} using the given {@link KeyValueAdapter} with a default
 	 * {@link KeyValueMappingContext}.
-	 * 
+	 *
 	 * @param adapter must not be {@literal null}.
 	 */
 	public KeyValueTemplate(KeyValueAdapter adapter) {
@@ -73,7 +73,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 
 	/**
 	 * Create new {@link KeyValueTemplate} using the given {@link KeyValueAdapter} and {@link MappingContext}.
-	 * 
+	 *
 	 * @param adapter must not be {@literal null}.
 	 * @param mappingContext must not be {@literal null}.
 	 */
@@ -90,7 +90,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 
 	/**
 	 * Set the {@link PersistenceExceptionTranslator} used for converting {@link RuntimeException}.
-	 * 
+	 *
 	 * @param exceptionTranslator must not be {@literal null}.
 	 */
 	public void setExceptionTranslator(PersistenceExceptionTranslator exceptionTranslator) {
@@ -101,7 +101,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 
 	/**
 	 * Define the event types to publish via {@link ApplicationEventPublisher}.
-	 * 
+	 *
 	 * @param eventTypesToPublish use {@literal null} or {@link Collections#emptySet()} to stop publishing.
 	 */
 	@SuppressWarnings("rawtypes")
@@ -247,7 +247,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 					return Collections.emptySet();
 				}
 
-				ArrayList<T> filtered = new ArrayList<T>();
+				ArrayList<T> filtered = new ArrayList<>();
 				for (Object candidate : values) {
 					if (typeCheck(type, candidate)) {
 						filtered.add((T) candidate);
@@ -407,7 +407,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 					return Collections.emptySet();
 				}
 
-				List<T> filtered = new ArrayList<T>();
+				List<T> filtered = new ArrayList<>();
 
 				for (Object candidate : result) {
 					if (typeCheck(type, candidate)) {

--- a/src/main/java/org/springframework/data/keyvalue/core/SpelQueryEngine.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SpelQueryEngine.java
@@ -30,7 +30,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 /**
  * {@link QueryEngine} implementation specific for executing {@link SpelExpression} based {@link KeyValueQuery} against
  * {@link KeyValueAdapter}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @param <T>
@@ -78,7 +78,7 @@ class SpelQueryEngine<T extends KeyValueAdapter> extends QueryEngine<KeyValueAda
 
 	private static <S> List<S> filterMatchingRange(Iterable<S> source, SpelCriteria criteria, long offset, int rows) {
 
-		List<S> result = new ArrayList<S>();
+		List<S> result = new ArrayList<>();
 
 		boolean compareOffsetAndRows = 0 < offset || 0 <= rows;
 		int remainingRows = rows;

--- a/src/main/java/org/springframework/data/keyvalue/core/event/KeyValueEvent.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/event/KeyValueEvent.java
@@ -23,7 +23,7 @@ import org.springframework.context.ApplicationEvent;
  * {@link KeyValueEvent} gets published for operations executed by eg.
  * {@link org.springframework.data.keyvalue.core.KeyValueTemplate}. Use the {@link #getType()} to determine which event
  * has been emitted.
- * 
+ *
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @param <T>
@@ -54,19 +54,19 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * Create new {@link BeforeGetEvent}.
-	 * 
+	 *
 	 * @param id
 	 * @param keySpace
 	 * @param type
 	 * @return
 	 */
 	public static <T> BeforeGetEvent<T> beforeGet(Serializable id, String keySpace, Class<T> type) {
-		return new BeforeGetEvent<T>(id, keySpace, type);
+		return new BeforeGetEvent<>(id, keySpace, type);
 	}
 
 	/**
 	 * Create new {@link AfterGetEvent}.
-	 * 
+	 *
 	 * @param id
 	 * @param keySpace
 	 * @param type
@@ -74,12 +74,12 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 * @return
 	 */
 	public static <T> AfterGetEvent<T> afterGet(Serializable id, String keySpace, Class<T> type, T value) {
-		return new AfterGetEvent<T>(id, keySpace, type, value);
+		return new AfterGetEvent<>(id, keySpace, type, value);
 	}
 
 	/**
 	 * Create new {@link BeforeInsertEvent}.
-	 * 
+	 *
 	 * @param id
 	 * @param keySpace
 	 * @param type
@@ -87,12 +87,12 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 * @return
 	 */
 	public static <T> BeforeInsertEvent<T> beforeInsert(Serializable id, String keySpace, Class<? extends T> type, T value) {
-		return new BeforeInsertEvent<T>(id, keySpace, type, value);
+		return new BeforeInsertEvent<>(id, keySpace, type, value);
 	}
 
 	/**
 	 * Create new {@link AfterInsertEvent}.
-	 * 
+	 *
 	 * @param id
 	 * @param keySpace
 	 * @param type
@@ -100,12 +100,12 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 * @return
 	 */
 	public static <T> AfterInsertEvent<T> afterInsert(Serializable id, String keySpace, Class<? extends T> type, T value) {
-		return new AfterInsertEvent<T>(id, keySpace, type, value);
+		return new AfterInsertEvent<>(id, keySpace, type, value);
 	}
 
 	/**
 	 * Create new {@link BeforeUpdateEvent}.
-	 * 
+	 *
 	 * @param id
 	 * @param keySpace
 	 * @param type
@@ -113,12 +113,12 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 * @return
 	 */
 	public static <T> BeforeUpdateEvent<T> beforeUpdate(Serializable id, String keySpace, Class<? extends T> type, T value) {
-		return new BeforeUpdateEvent<T>(id, keySpace, type, value);
+		return new BeforeUpdateEvent<>(id, keySpace, type, value);
 	}
 
 	/**
 	 * Create new {@link AfterUpdateEvent}.
-	 * 
+	 *
 	 * @param id
 	 * @param keySpace
 	 * @param type
@@ -128,46 +128,46 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 */
 	public static <T> AfterUpdateEvent<T> afterUpdate(Serializable id, String keySpace, Class<? extends T> type,
 			T actualValue, Object previousValue) {
-		return new AfterUpdateEvent<T>(id, keySpace, type, actualValue, previousValue);
+		return new AfterUpdateEvent<>(id, keySpace, type, actualValue, previousValue);
 	}
 
 	/**
 	 * Create new {@link BeforeDropKeySpaceEvent}.
-	 * 
+	 *
 	 * @param keySpace
 	 * @param type
 	 * @return
 	 */
 	public static <T> BeforeDropKeySpaceEvent<T> beforeDropKeySpace(String keySpace, Class<? extends T> type) {
-		return new BeforeDropKeySpaceEvent<T>(keySpace, type);
+		return new BeforeDropKeySpaceEvent<>(keySpace, type);
 	}
 
 	/**
 	 * Create new {@link AfterDropKeySpaceEvent}.
-	 * 
+	 *
 	 * @param keySpace
 	 * @param type
 	 * @return
 	 */
 	public static <T> AfterDropKeySpaceEvent<T> afterDropKeySpace(String keySpace, Class<? extends T> type) {
-		return new AfterDropKeySpaceEvent<T>(keySpace, type);
+		return new AfterDropKeySpaceEvent<>(keySpace, type);
 	}
 
 	/**
 	 * Create new {@link BeforeDeleteEvent}.
-	 * 
+	 *
 	 * @param id
 	 * @param keySpace
 	 * @param type
 	 * @return
 	 */
 	public static <T> BeforeDeleteEvent<T> beforeDelete(Serializable id, String keySpace, Class<? extends T> type) {
-		return new BeforeDeleteEvent<T>(id, keySpace, type);
+		return new BeforeDeleteEvent<>(id, keySpace, type);
 	}
 
 	/**
 	 * Create new {@link AfterDeleteEvent}.
-	 * 
+	 *
 	 * @param id
 	 * @param keySpace
 	 * @param type
@@ -175,7 +175,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 * @return
 	 */
 	public static <T> AfterDeleteEvent<T> afterDelete(Serializable id, String keySpace, Class<? extends T> type, T value) {
-		return new AfterDeleteEvent<T>(id, keySpace, type, value);
+		return new AfterDeleteEvent<>(id, keySpace, type, value);
 	}
 
 	/**
@@ -209,7 +209,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 		/**
 		 * Get the type of the element the {@link KeyValueEvent} refers to.
-		 * 
+		 *
 		 * @return
 		 */
 		public Class<? extends T> getType() {
@@ -233,7 +233,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 		/**
 		 * Get the value of the element the {@link KeyValueEvent} refers to. Can be {@literal null}.
-		 * 
+		 *
 		 * @return
 		 */
 		public T getPayload() {
@@ -243,7 +243,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} raised before loading an object by its {@literal key}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -258,7 +258,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} after loading an object by its {@literal key}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -273,7 +273,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} before inserting an object by with a given {@literal key}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -288,7 +288,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} after inserting an object by with a given {@literal key}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -302,7 +302,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} before updating an object by with a given {@literal key}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -316,7 +316,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} after updating an object by with a given {@literal key}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -332,7 +332,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 		/**
 		 * Get the value before update. Can be {@literal null}.
-		 * 
+		 *
 		 * @return
 		 */
 		public Object before() {
@@ -341,7 +341,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 		/**
 		 * Get the current value.
-		 * 
+		 *
 		 * @return
 		 */
 		public T after() {
@@ -351,7 +351,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} before removing an object by with a given {@literal key}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -365,7 +365,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} after removing an object by with a given {@literal key}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -379,7 +379,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} before removing all elements in a given {@literal keySpace}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */
@@ -400,7 +400,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 
 	/**
 	 * {@link KeyValueEvent} after removing all elements in a given {@literal keySpace}.
-	 * 
+	 *
 	 * @author Christoph Strobl
 	 * @param <T>
 	 */

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/AnnotationBasedKeySpaceResolver.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/AnnotationBasedKeySpaceResolver.java
@@ -34,7 +34,7 @@ import org.springframework.util.ObjectUtils;
 /**
  * {@link AnnotationBasedKeySpaceResolver} looks up {@link Persistent} and checks for presence of either meta or direct
  * usage of {@link KeySpace}. If non found it will default the keyspace to {@link Class#getName()}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  */
@@ -142,7 +142,7 @@ enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 		 */
 		public static <T extends Annotation> AnnotationDescriptor<T> findAnnotationDescriptor(Class<?> clazz,
 				Class<T> annotationType) {
-			return findAnnotationDescriptor(clazz, new HashSet<Annotation>(), annotationType);
+			return findAnnotationDescriptor(clazz, new HashSet<>(), annotationType);
 		}
 
 		/**
@@ -165,7 +165,7 @@ enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 
 			// Declared locally?
 			if (AnnotationUtils.isAnnotationDeclaredLocally(annotationType, clazz)) {
-				return new AnnotationDescriptor<T>(clazz, clazz.getAnnotation(annotationType));
+				return new AnnotationDescriptor<>(clazz, clazz.getAnnotation(annotationType));
 			}
 
 			// Declared on a composed annotation (i.e., as a meta-annotation)?
@@ -174,7 +174,7 @@ enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 					AnnotationDescriptor<T> descriptor = findAnnotationDescriptor(composedAnnotation.annotationType(), visited,
 							annotationType);
 					if (descriptor != null) {
-						return new AnnotationDescriptor<T>(clazz, descriptor.getDeclaringClass(), composedAnnotation,
+						return new AnnotationDescriptor<>(clazz, descriptor.getDeclaringClass(), composedAnnotation,
 								descriptor.getAnnotation());
 					}
 				}
@@ -218,7 +218,7 @@ enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 		 */
 		public static UntypedAnnotationDescriptor findAnnotationDescriptorForTypes(Class<?> clazz,
 				Class<? extends Annotation>... annotationTypes) {
-			return findAnnotationDescriptorForTypes(clazz, new HashSet<Annotation>(), annotationTypes);
+			return findAnnotationDescriptorForTypes(clazz, new HashSet<>(), annotationTypes);
 		}
 
 		/**
@@ -301,7 +301,7 @@ enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 		 * &#064;Retention(RetentionPolicy.RUNTIME)
 		 * public @interface RepositoryTests {
 		 * }
-		 * 
+		 *
 		 * &#064;RepositoryTests
 		 * public class UserRepositoryTests {}
 		 * </pre>

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/KeyValuePersistentProperty.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/KeyValuePersistentProperty.java
@@ -24,7 +24,7 @@ import org.springframework.data.mapping.model.SimpleTypeHolder;
 
 /**
  * Most trivial implementation of {@link PersistentProperty}.
- * 
+ *
  * @author Christoph Strobl
  */
 public class KeyValuePersistentProperty<P extends KeyValuePersistentProperty<P>>
@@ -41,6 +41,6 @@ public class KeyValuePersistentProperty<P extends KeyValuePersistentProperty<P>>
 	 */
 	@Override
 	protected Association<P> createAssociation() {
-		return new Association<P>((P) this, null);
+		return new Association<>((P) this, null);
 	}
 }

--- a/src/main/java/org/springframework/data/keyvalue/core/query/KeyValueQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/query/KeyValueQuery.java
@@ -19,11 +19,12 @@ import org.springframework.data.domain.Sort;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @param <T> Criteria type
  */
 public class KeyValueQuery<T> {
 
-	private Sort sort;
+	private Sort sort = Sort.unsorted();
 	private long offset = -1;
 	private int rows = -1;
 	private T criteria;
@@ -35,7 +36,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Creates new instance of {@link KeyValueQuery} with given criteria.
-	 * 
+	 *
 	 * @param criteria can be {@literal null}.
 	 */
 	public KeyValueQuery(T criteria) {
@@ -44,7 +45,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Creates new instance of {@link KeyValueQuery} with given {@link Sort}.
-	 * 
+	 *
 	 * @param sort can be {@literal null}.
 	 */
 	public KeyValueQuery(Sort sort) {
@@ -53,7 +54,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Get the criteria object.
-	 * 
+	 *
 	 * @return
 	 */
 	public T getCritieria() {
@@ -62,7 +63,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Get {@link Sort}.
-	 * 
+	 *
 	 * @return
 	 */
 	public Sort getSort() {
@@ -71,7 +72,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Number of elements to skip.
-	 * 
+	 *
 	 * @return negative value if not set.
 	 */
 	public long getOffset() {
@@ -80,7 +81,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Number of elements to read.
-	 * 
+	 *
 	 * @return negative value if not set.
 	 */
 	public int getRows() {
@@ -89,7 +90,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Set the number of elements to skip.
-	 * 
+	 *
 	 * @param offset use negative value for none.
 	 */
 	public void setOffset(long offset) {
@@ -98,8 +99,8 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Set the number of elements to read.
-	 * 
-	 * @param offset use negative value for all.
+	 *
+	 * @param rows use negative value for all.
 	 */
 	public void setRows(int rows) {
 		this.rows = rows;
@@ -107,7 +108,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Set {@link Sort} to be applied.
-	 * 
+	 *
 	 * @param sort
 	 */
 	public void setSort(Sort sort) {
@@ -116,7 +117,7 @@ public class KeyValueQuery<T> {
 
 	/**
 	 * Add given {@link Sort}.
-	 * 
+	 *
 	 * @param sort {@literal null} {@link Sort} will be ignored.
 	 * @return
 	 */
@@ -127,7 +128,7 @@ public class KeyValueQuery<T> {
 		}
 
 		if (this.sort != null) {
-			this.sort.and(sort);
+			this.sort = this.sort.and(sort);
 		} else {
 			this.sort = sort;
 		}
@@ -135,7 +136,7 @@ public class KeyValueQuery<T> {
 	}
 
 	/**
-	 * @see KeyValueQuery#setOffset(int)
+	 * @see KeyValueQuery#setOffset(long)
 	 * @param offset
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
@@ -41,7 +41,7 @@ import org.springframework.util.ClassUtils;
 /**
  * {@link RepositoryQuery} implementation deriving queries from {@link PartTree} using a predefined
  * {@link AbstractQueryCreator}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Mark Paluch
@@ -56,7 +56,7 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 	/**
 	 * Creates a new {@link KeyValuePartTreeQuery} for the given {@link QueryMethod}, {@link EvaluationContextProvider},
 	 * {@link KeyValueOperations} and query creator type.
-	 * 
+	 *
 	 * @param queryMethod must not be {@literal null}.
 	 * @param evaluationContextProvider must not be {@literal null}.
 	 * @param keyValueOperations must not be {@literal null}.
@@ -157,7 +157,7 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 			query.setRows(instance.getRows());
 		}
 
-		query.setSort(sort == null || Sort.unsorted().equals(sort) ? instance.getSort() : sort);
+		query.setSort(sort == null || sort.isUnsorted() ? instance.getSort() : sort);
 
 		return query;
 	}
@@ -179,7 +179,7 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 
 		PartTree tree = new PartTree(getQueryMethod().getName(), getQueryMethod().getEntityInformation().getJavaType());
 
-		Constructor<? extends AbstractQueryCreator<?, ?>> constructor = (Constructor<? extends AbstractQueryCreator<?, ?>>) ClassUtils
+		Constructor<? extends AbstractQueryCreator<?, ?>> constructor = ClassUtils
 				.getConstructorIfAvailable(queryCreator, PartTree.class, ParameterAccessor.class);
 		KeyValueQuery<?> query = (KeyValueQuery<?>) BeanUtils.instantiateClass(constructor, tree, accessor).createQuery();
 

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/SpelQueryCreator.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/SpelQueryCreator.java
@@ -32,7 +32,7 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
  * {@link AbstractQueryCreator} to create {@link SpelExpression} based {@link KeyValueQuery}s.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  */
@@ -44,7 +44,7 @@ public class SpelQueryCreator extends AbstractQueryCreator<KeyValueQuery<SpelExp
 
 	/**
 	 * Creates a new {@link SpelQueryCreator} for the given {@link PartTree} and {@link ParameterAccessor}.
-	 * 
+	 *
 	 * @param tree must not be {@literal null}.
 	 * @param parameters must not be {@literal null}.
 	 */
@@ -85,7 +85,7 @@ public class SpelQueryCreator extends AbstractQueryCreator<KeyValueQuery<SpelExp
 	@Override
 	protected KeyValueQuery<SpelExpression> complete(String criteria, Sort sort) {
 
-		KeyValueQuery<SpelExpression> query = new KeyValueQuery<SpelExpression>(this.expression);
+		KeyValueQuery<SpelExpression> query = new KeyValueQuery<>(this.expression);
 
 		if (sort != null) {
 			query.orderBy(sort);

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueQuerydslUtils.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueQuerydslUtils.java
@@ -33,7 +33,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
 
 /**
  * Utilities for Querydsl usage.
- * 
+ *
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Oliver Gierke
@@ -46,7 +46,7 @@ abstract class KeyValueQuerydslUtils {
 
 	/**
 	 * Transforms a plain {@link Order} into a QueryDsl specific {@link OrderSpecifier}.
-	 * 
+	 *
 	 * @param sort
 	 * @param builder must not be {@literal null}.
 	 * @return empty {@code OrderSpecifier<?>[]} when sort is {@literal null}.
@@ -65,7 +65,7 @@ abstract class KeyValueQuerydslUtils {
 			specifiers = ((QSort) sort).getOrderSpecifiers();
 		} else {
 
-			specifiers = new ArrayList<OrderSpecifier<?>>();
+			specifiers = new ArrayList<>();
 			for (Order order : sort) {
 				specifiers.add(toOrderSpecifier(order, builder));
 			}
@@ -83,7 +83,7 @@ abstract class KeyValueQuerydslUtils {
 
 	/**
 	 * Creates an {@link Expression} for the given {@link Order} property.
-	 * 
+	 *
 	 * @param order must not be {@literal null}.
 	 * @param builder must not be {@literal null}.
 	 * @return
@@ -114,7 +114,7 @@ abstract class KeyValueQuerydslUtils {
 	/**
 	 * Converts the given {@link org.springframework.data.domain.Sort.NullHandling} to the appropriate Querydsl
 	 * {@link NullHandling}.
-	 * 
+	 *
 	 * @param nullHandling must not be {@literal null}.
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactory.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.keyvalue.repository.support;
 
-import static org.springframework.data.querydsl.QuerydslUtils.*;
+import static org.springframework.data.querydsl.QuerydslUtils.QUERY_DSL_PRESENT;
 
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
@@ -48,7 +48,7 @@ import org.springframework.util.ClassUtils;
 /**
  * {@link RepositoryFactorySupport} specific of handing
  * {@link org.springframework.data.keyvalue.repository.KeyValueRepository}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  */
@@ -63,7 +63,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 
 	/**
 	 * Creates a new {@link KeyValueRepositoryFactory} for the given {@link KeyValueOperations}.
-	 * 
+	 *
 	 * @param keyValueOperations must not be {@literal null}.
 	 */
 	public KeyValueRepositoryFactory(KeyValueOperations keyValueOperations) {
@@ -73,7 +73,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 	/**
 	 * Creates a new {@link KeyValueRepositoryFactory} for the given {@link KeyValueOperations} and
 	 * {@link AbstractQueryCreator}-type.
-	 * 
+	 *
 	 * @param keyValueOperations must not be {@literal null}.
 	 * @param queryCreator defaulted to {@link #DEFAULT_QUERY_CREATOR} if {@literal null}.
 	 */
@@ -86,7 +86,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 	/**
 	 * Creates a new {@link KeyValueRepositoryFactory} for the given {@link KeyValueOperations} and
 	 * {@link AbstractQueryCreator}-type.
-	 * 
+	 *
 	 * @param keyValueOperations must not be {@literal null}.
 	 * @param queryCreator must not be {@literal null}.
 	 * @param repositoryQueryType must not be {@literal null}.
@@ -114,7 +114,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 	public <T, ID extends Serializable> EntityInformation<T, ID> getEntityInformation(Class<T> domainClass) {
 
 		PersistentEntity<T, ?> entity = (PersistentEntity<T, ?>) context.getPersistentEntity(domainClass).get();
-		PersistentEntityInformation<T, ID> entityInformation = new PersistentEntityInformation<T, ID>(entity);
+		PersistentEntityInformation<T, ID> entityInformation = new PersistentEntityInformation<>(entity);
 
 		return entityInformation;
 	}
@@ -142,7 +142,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 
 	/**
 	 * Returns whether the given repository interface requires a QueryDsl specific implementation to be chosen.
-	 * 
+	 *
 	 * @param repositoryInterface must not be {@literal null}.
 	 * @return
 	 */
@@ -177,7 +177,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 		 * {@link KeyValueOperations} and query creator type.
 		 * <p>
 		 * TODO: Key is not considered. Should it?
-		 * 
+		 *
 		 * @param key
 		 * @param evaluationContextProvider must not be {@literal null}.
 		 * @param keyValueOperations must not be {@literal null}.
@@ -210,7 +210,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 			this.repositoryQueryType = repositoryQueryType;
 		}
 
-		/* 
+		/*
 		 * (non-Javadoc)
 		 * @see org.springframework.data.repository.query.QueryLookupStrategy#resolveQuery(java.lang.reflect.Method, org.springframework.data.repository.core.RepositoryMetadata, org.springframework.data.projection.ProjectionFactory, org.springframework.data.repository.core.NamedQueries)
 		 */

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/QuerydslKeyValueRepository.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/QuerydslKeyValueRepository.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.keyvalue.repository.support;
 
-import static org.springframework.data.keyvalue.repository.support.KeyValueQuerydslUtils.*;
+import static org.springframework.data.keyvalue.repository.support.KeyValueQuerydslUtils.toOrderSpecifier;
 
 import java.io.Serializable;
 
@@ -41,7 +41,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
 
 /**
  * {@link KeyValueRepository} implementation capable of executing {@link Predicate}s using {@link CollQuery}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Thomas Darimont
@@ -59,7 +59,7 @@ public class QuerydslKeyValueRepository<T, ID extends Serializable> extends Simp
 	/**
 	 * Creates a new {@link QuerydslKeyValueRepository} for the given {@link EntityInformation} and
 	 * {@link KeyValueOperations}.
-	 * 
+	 *
 	 * @param entityInformation must not be {@literal null}.
 	 * @param operations must not be {@literal null}.
 	 */
@@ -70,7 +70,7 @@ public class QuerydslKeyValueRepository<T, ID extends Serializable> extends Simp
 	/**
 	 * Creates a new {@link QuerydslKeyValueRepository} for the given {@link EntityInformation},
 	 * {@link KeyValueOperations} and {@link EntityPathResolver}.
-	 * 
+	 *
 	 * @param entityInformation must not be {@literal null}.
 	 * @param operations must not be {@literal null}.
 	 * @param resolver must not be {@literal null}.
@@ -83,7 +83,7 @@ public class QuerydslKeyValueRepository<T, ID extends Serializable> extends Simp
 		Assert.notNull(resolver, "EntityPathResolver must not be null!");
 
 		this.path = resolver.createPath(entityInformation.getJavaType());
-		this.builder = new PathBuilder<T>(path.getType(), path.getMetadata());
+		this.builder = new PathBuilder<>(path.getType(), path.getMetadata());
 	}
 
 	/*
@@ -117,7 +117,7 @@ public class QuerydslKeyValueRepository<T, ID extends Serializable> extends Simp
 		return query.fetchResults().getResults();
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Sort)
 	 */
@@ -145,7 +145,7 @@ public class QuerydslKeyValueRepository<T, ID extends Serializable> extends Simp
 			}
 		}
 
-		return new PageImpl<T>(query.fetchResults().getResults(), pageable, count(predicate));
+		return new PageImpl<>(query.fetchResults().getResults(), pageable, count(predicate));
 	}
 
 	/*
@@ -174,7 +174,7 @@ public class QuerydslKeyValueRepository<T, ID extends Serializable> extends Simp
 		return prepareQuery(predicate).fetchCount();
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#exists(com.mysema.query.types.Predicate)
 	 */
@@ -185,13 +185,13 @@ public class QuerydslKeyValueRepository<T, ID extends Serializable> extends Simp
 
 	/**
 	 * Creates executable query for given {@link Predicate}.
-	 * 
+	 *
 	 * @param predicate
 	 * @return
 	 */
 	protected AbstractCollQuery<T, ?> prepareQuery(Predicate predicate) {
 
-		CollQuery<T> query = new CollQuery<T>();
+		CollQuery<T> query = new CollQuery<>();
 		query.from(builder, findAll());
 
 		return predicate != null ? query.where(predicate) : query;

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/SimpleKeyValueRepository.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/SimpleKeyValueRepository.java
@@ -44,7 +44,7 @@ public class SimpleKeyValueRepository<T, ID extends Serializable> implements Key
 	/**
 	 * Creates a new {@link SimpleKeyValueRepository} for the given {@link EntityInformation} and
 	 * {@link KeyValueOperations}.
-	 * 
+	 *
 	 * @param metadata must not be {@literal null}.
 	 * @param operations must not be {@literal null}.
 	 */
@@ -75,13 +75,13 @@ public class SimpleKeyValueRepository<T, ID extends Serializable> implements Key
 
 		if (pageable == null) {
 			List<T> result = findAll();
-			return new PageImpl<T>(result, Pageable.unpaged(), result.size());
+			return new PageImpl<>(result, Pageable.unpaged(), result.size());
 		}
 
 		Iterable<T> content = operations.findInRange(pageable.getOffset(), pageable.getPageSize(), pageable.getSort(),
 				entityInformation.getJavaType());
 
-		return new PageImpl<T>(IterableConverter.toList(content), pageable,
+		return new PageImpl<>(IterableConverter.toList(content), pageable,
 				this.operations.count(entityInformation.getJavaType()));
 	}
 
@@ -150,7 +150,7 @@ public class SimpleKeyValueRepository<T, ID extends Serializable> implements Key
 	@Override
 	public Iterable<T> findAll(Iterable<ID> ids) {
 
-		List<T> result = new ArrayList<T>();
+		List<T> result = new ArrayList<>();
 
 		for (ID id : ids) {
 

--- a/src/main/java/org/springframework/data/map/MapKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/map/MapKeyValueAdapter.java
@@ -31,7 +31,7 @@ import org.springframework.util.ClassUtils;
 
 /**
  * {@link KeyValueAdapter} implementation for {@link Map}.
- * 
+ *
  * @author Christoph Strobl
  */
 public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
@@ -49,7 +49,7 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 
 	/**
 	 * Creates a new {@link MapKeyValueAdapter} using the given {@link Map} as backing store.
-	 * 
+	 *
 	 * @param mapType must not be {@literal null}.
 	 */
 	@SuppressWarnings("rawtypes")
@@ -59,7 +59,7 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 
 	/**
 	 * Create new instance of {@link MapKeyValueAdapter} using given dataStore for persistence.
-	 * 
+	 *
 	 * @param store must not be {@literal null}.
 	 */
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -69,7 +69,7 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 
 	/**
 	 * Creates a new {@link MapKeyValueAdapter} with the given store and type to be used when creating key spaces.
-	 * 
+	 *
 	 * @param store must not be {@literal null}.
 	 * @param keySpaceMapType must not be {@literal null}.
 	 */
@@ -150,7 +150,7 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 	 */
 	@Override
 	public CloseableIterator<Entry<Serializable, Object>> entries(Serializable keyspace) {
-		return new ForwardingCloseableIterator<Entry<Serializable, Object>>(getKeySpaceMap(keyspace).entrySet().iterator());
+		return new ForwardingCloseableIterator<>(getKeySpaceMap(keyspace).entrySet().iterator());
 	}
 
 	/*
@@ -182,7 +182,7 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 
 	/**
 	 * Get map associated with given key space.
-	 * 
+	 *
 	 * @param keyspace must not be {@literal null}.
 	 * @return
 	 */

--- a/src/test/java/org/springframework/data/keyvalue/core/ForwardingCloseableIteratorUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/ForwardingCloseableIteratorUnitTests.java
@@ -15,10 +15,14 @@
  */
 package org.springframework.data.keyvalue.core;
 
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.core.IsNull.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -29,6 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.data.util.CloseableIterator;
 
 /**
@@ -47,7 +52,7 @@ public class ForwardingCloseableIteratorUnitTests<K, V> {
 
 		when(iteratorMock.hasNext()).thenReturn(true);
 
-		CloseableIterator<Entry<K, V>> iterator = new ForwardingCloseableIterator<Entry<K, V>>(iteratorMock);
+		CloseableIterator<Entry<K, V>> iterator = new ForwardingCloseableIterator<>(iteratorMock);
 
 		try {
 			assertThat(iterator.hasNext(), is(true));
@@ -63,7 +68,7 @@ public class ForwardingCloseableIteratorUnitTests<K, V> {
 
 		when(iteratorMock.next()).thenReturn((Entry<K, V>) mock(Map.Entry.class));
 
-		CloseableIterator<Entry<K, V>> iterator = new ForwardingCloseableIterator<Entry<K, V>>(iteratorMock);
+		CloseableIterator<Entry<K, V>> iterator = new ForwardingCloseableIterator<>(iteratorMock);
 
 		try {
 			assertThat(iterator.next(), notNullValue());
@@ -78,7 +83,7 @@ public class ForwardingCloseableIteratorUnitTests<K, V> {
 
 		when(iteratorMock.next()).thenThrow(new NoSuchElementException());
 
-		CloseableIterator<Entry<K, V>> iterator = new ForwardingCloseableIterator<Entry<K, V>>(iteratorMock);
+		CloseableIterator<Entry<K, V>> iterator = new ForwardingCloseableIterator<>(iteratorMock);
 
 		try {
 			iterator.next();
@@ -90,7 +95,7 @@ public class ForwardingCloseableIteratorUnitTests<K, V> {
 	@Test // DATAKV-99
 	public void closeShouldDoNothingByDefault() {
 
-		new ForwardingCloseableIterator<Entry<K, V>>(iteratorMock).close();
+		new ForwardingCloseableIterator<>(iteratorMock).close();
 
 		verifyZeroInteractions(iteratorMock);
 	}
@@ -98,7 +103,7 @@ public class ForwardingCloseableIteratorUnitTests<K, V> {
 	@Test // DATAKV-99
 	public void closeShouldInvokeConfiguredCloseAction() {
 
-		new ForwardingCloseableIterator<Entry<K, V>>(iteratorMock, closeActionMock).close();
+		new ForwardingCloseableIterator<>(iteratorMock, closeActionMock).close();
 
 		verify(closeActionMock, times(1)).run();
 	}

--- a/src/test/java/org/springframework/data/keyvalue/core/IterableConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/IterableConverterUnitTests.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.data.keyvalue.core;
 
-import static org.hamcrest.collection.IsEmptyCollection.*;
-import static org.hamcrest.collection.IsIterableContainingInOrder.*;
-import static org.hamcrest.core.IsInstanceOf.*;
-import static org.hamcrest.core.IsNull.*;
-import static org.hamcrest.core.IsSame.*;
-import static org.junit.Assert.*;
-import static org.springframework.data.keyvalue.core.IterableConverter.*;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.springframework.data.keyvalue.core.IterableConverter.toList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,7 +50,7 @@ public class IterableConverterUnitTests {
 	@Test // DATAKV-101
 	public void toListShouldReturnSameObjectWhenSourceIsAlreadyListType() {
 
-		List<String> source = new ArrayList<String>();
+		List<String> source = new ArrayList<>();
 
 		assertThat(toList(source), sameInstance(source));
 	}
@@ -58,7 +58,7 @@ public class IterableConverterUnitTests {
 	@Test // DATAKV-101
 	public void toListShouldReturnListWhenSourceIsNonListType() {
 
-		Set<String> source = new HashSet<String>();
+		Set<String> source = new HashSet<>();
 		source.add("tyrion");
 
 		assertThat(toList(source), instanceOf(List.class));
@@ -67,7 +67,7 @@ public class IterableConverterUnitTests {
 	@Test // DATAKV-101
 	public void toListShouldHoldValuesInOrderOfSource() {
 
-		Set<String> source = new LinkedHashSet<String>();
+		Set<String> source = new LinkedHashSet<>();
 		source.add("tyrion");
 		source.add("jaime");
 

--- a/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateTests.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.data.keyvalue.core;
 
-import static org.hamcrest.collection.IsCollectionWithSize.*;
-import static org.hamcrest.collection.IsEmptyIterable.*;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.*;
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.core.IsNull.*;
-import static org.hamcrest.core.IsSame.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyIterable.emptyIterable;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.Assert.assertThat;
 
 import java.io.Serializable;
 import java.lang.annotation.ElementType;
@@ -34,6 +34,7 @@ import java.util.Optional;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Persistent;
@@ -54,7 +55,7 @@ public class KeyValueTemplateTests {
 	static final Bar BAR_ONE = new Bar("one");
 	static final ClassWithTypeAlias ALIASED = new ClassWithTypeAlias("super");
 	static final SubclassOfAliasedType SUBCLASS_OF_ALIASED = new SubclassOfAliasedType("sub");
-	static final KeyValueQuery<String> STRING_QUERY = new KeyValueQuery<String>("foo == 'two'");
+	static final KeyValueQuery<String> STRING_QUERY = new KeyValueQuery<>("foo == 'two'");
 
 	KeyValueTemplate operations;
 

--- a/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
@@ -15,11 +15,20 @@
  */
 package org.springframework.data.keyvalue.core;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.*;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -37,6 +46,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -75,7 +85,7 @@ public class KeyValueTemplateUnitTests {
 			"super");
 	private static final SubclassOfTypeWithCustomComposedKeySpaceAnnotation SUBCLASS_OF_ALIASED = new SubclassOfTypeWithCustomComposedKeySpaceAnnotation(
 			"sub");
-	private static final KeyValueQuery<String> STRING_QUERY = new KeyValueQuery<String>("foo == 'two'");
+	private static final KeyValueQuery<String> STRING_QUERY = new KeyValueQuery<>("foo == 'two'");
 
 	private @Mock KeyValueAdapter adapterMock;
 	private KeyValueTemplate template;
@@ -557,7 +567,7 @@ public class KeyValueTemplateUnitTests {
 
 	@SuppressWarnings("rawtypes")
 	private void setEventsToPublish(Class<? extends KeyValueEvent>... events) {
-		template.setEventTypesToPublish(new HashSet<Class<? extends KeyValueEvent>>(Arrays.asList(events)));
+		template.setEventTypesToPublish(new HashSet<>(Arrays.asList(events)));
 	}
 
 	static class Foo {

--- a/src/test/java/org/springframework/data/keyvalue/core/SpelPropertyComperatorUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/SpelPropertyComperatorUnitTests.java
@@ -15,19 +15,21 @@
  */
 package org.springframework.data.keyvalue.core;
 
-import static java.lang.Integer.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.number.OrderingComparison.*;
-import static org.junit.Assert.*;
+import static java.lang.Integer.valueOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+import static org.junit.Assert.assertThat;
 
 import java.util.Comparator;
 
 import org.junit.Test;
+
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
  * Unit tests for {@link SpelPropertyComparator}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  */
@@ -43,7 +45,7 @@ public class SpelPropertyComperatorUnitTests {
 	@Test // DATACMNS-525
 	public void shouldCompareStringAscCorrectly() {
 
-		Comparator<SomeType> comparator = new SpelPropertyComparator<SomeType>("stringProperty", PARSER);
+		Comparator<SomeType> comparator = new SpelPropertyComparator<>("stringProperty", PARSER);
 		assertThat(comparator.compare(ONE, TWO), is(ONE.getStringProperty().compareTo(TWO.getStringProperty())));
 	}
 
@@ -57,7 +59,7 @@ public class SpelPropertyComperatorUnitTests {
 	@Test // DATACMNS-525
 	public void shouldCompareIntegerAscCorrectly() {
 
-		Comparator<SomeType> comparator = new SpelPropertyComparator<SomeType>("integerProperty", PARSER);
+		Comparator<SomeType> comparator = new SpelPropertyComparator<>("integerProperty", PARSER);
 		assertThat(comparator.compare(ONE, TWO), is(ONE.getIntegerProperty().compareTo(TWO.getIntegerProperty())));
 	}
 
@@ -71,7 +73,7 @@ public class SpelPropertyComperatorUnitTests {
 	@Test // DATACMNS-525
 	public void shouldComparePrimitiveIntegerAscCorrectly() {
 
-		Comparator<SomeType> comparator = new SpelPropertyComparator<SomeType>("primitiveProperty", PARSER);
+		Comparator<SomeType> comparator = new SpelPropertyComparator<>("primitiveProperty", PARSER);
 		assertThat(comparator.compare(ONE, TWO),
 				is(valueOf(ONE.getPrimitiveProperty()).compareTo(valueOf(TWO.getPrimitiveProperty()))));
 	}
@@ -79,7 +81,7 @@ public class SpelPropertyComperatorUnitTests {
 	@Test // DATACMNS-525
 	public void shouldNotFailOnNullValues() {
 
-		Comparator<SomeType> comparator = new SpelPropertyComparator<SomeType>("stringProperty", PARSER);
+		Comparator<SomeType> comparator = new SpelPropertyComparator<>("stringProperty", PARSER);
 		assertThat(comparator.compare(ONE, new SomeType(null, null, 2)), is(1));
 	}
 
@@ -107,7 +109,7 @@ public class SpelPropertyComperatorUnitTests {
 	@Test // DATACMNS-525
 	public void shouldCompareNestedTypesCorrectly() {
 
-		Comparator<WrapperType> comparator = new SpelPropertyComparator<WrapperType>("nestedType.stringProperty", PARSER);
+		Comparator<WrapperType> comparator = new SpelPropertyComparator<>("nestedType.stringProperty", PARSER);
 		assertThat(comparator.compare(WRAPPER_ONE, WRAPPER_TWO), is(WRAPPER_ONE.getNestedType().getStringProperty()
 				.compareTo(WRAPPER_TWO.getNestedType().getStringProperty())));
 	}
@@ -115,7 +117,7 @@ public class SpelPropertyComperatorUnitTests {
 	@Test // DATACMNS-525
 	public void shouldCompareNestedTypesCorrectlyWhenOneOfThemHasNullValue() {
 
-		SpelPropertyComparator<WrapperType> comparator = new SpelPropertyComparator<WrapperType>(
+		SpelPropertyComparator<WrapperType> comparator = new SpelPropertyComparator<>(
 				"nestedType.stringProperty", PARSER);
 		assertThat(comparator.compare(WRAPPER_ONE, new WrapperType("two", null)), is(greaterThanOrEqualTo(1)));
 	}

--- a/src/test/java/org/springframework/data/keyvalue/core/SpelQueryEngineUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/SpelQueryEngineUnitTests.java
@@ -15,11 +15,12 @@
  */
 package org.springframework.data.keyvalue.core;
 
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.keyvalue.repository.query.SpelQueryCreator;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
@@ -43,7 +45,7 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 /**
  * Unit tests for {@link SpelQueryEngine}.
- * 
+ *
  * @author Martin Macko
  * @author Oliver Gierke
  */
@@ -62,7 +64,7 @@ public class SpelQueryEngineUnitTests {
 	@Before
 	public void setUp() {
 
-		engine = new SpelQueryEngine<KeyValueAdapter>();
+		engine = new SpelQueryEngine<>();
 		engine.registerAdapter(adapter);
 	}
 
@@ -86,7 +88,7 @@ public class SpelQueryEngineUnitTests {
 
 	private static SpelCriteria createQueryForMethodWithArgs(String methodName, Object... args) throws Exception {
 
-		List<Class<?>> types = new ArrayList<Class<?>>(args.length);
+		List<Class<?>> types = new ArrayList<>(args.length);
 
 		for (Object arg : args) {
 			types.add(arg.getClass());

--- a/src/test/java/org/springframework/data/keyvalue/repository/SimpleKeyValueRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/SimpleKeyValueRepositoryUnitTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.data.keyvalue.repository;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -27,6 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Persistent;
 import org.springframework.data.domain.PageRequest;
@@ -48,16 +53,16 @@ public class SimpleKeyValueRepositoryUnitTests {
 	@Before
 	public void setUp() {
 
-		ReflectionEntityInformation<Foo, String> ei = new ReflectionEntityInformation<Foo, String>(Foo.class);
-		repo = new SimpleKeyValueRepository<Foo, String>(ei, opsMock);
+		ReflectionEntityInformation<Foo, String> ei = new ReflectionEntityInformation<>(Foo.class);
+		repo = new SimpleKeyValueRepository<>(ei, opsMock);
 	}
 
 	@Test // DATACMNS-525
 	public void saveNewWithNumericId() {
 
-		ReflectionEntityInformation<WithNumericId, Integer> ei = new ReflectionEntityInformation<WithNumericId, Integer>(
+		ReflectionEntityInformation<WithNumericId, Integer> ei = new ReflectionEntityInformation<>(
 				WithNumericId.class);
-		SimpleKeyValueRepository<WithNumericId, Integer> temp = new SimpleKeyValueRepository<WithNumericId, Integer>(ei,
+		SimpleKeyValueRepository<WithNumericId, Integer> temp = new SimpleKeyValueRepository<>(ei,
 				opsMock);
 
 		WithNumericId withNumericId = new WithNumericId();
@@ -129,7 +134,7 @@ public class SimpleKeyValueRepositoryUnitTests {
 	@Test // DATACMNS-525
 	public void findAllWithPageableShouldDelegateToOperationsCorrectlyWhenPageableDoesNotContainSort() {
 
-		repo.findAll(new PageRequest(10, 15));
+		repo.findAll(PageRequest.of(10, 15));
 
 		verify(opsMock, times(1)).findInRange(eq(150L), eq(15), eq(Sort.unsorted()), eq(Foo.class));
 	}
@@ -137,8 +142,8 @@ public class SimpleKeyValueRepositoryUnitTests {
 	@Test // DATACMNS-525
 	public void findAllWithPageableShouldDelegateToOperationsCorrectlyWhenPageableContainsSort() {
 
-		Sort sort = new Sort("for", "bar");
-		repo.findAll(new PageRequest(10, 15, sort));
+		Sort sort = Sort.by("for", "bar");
+		repo.findAll(PageRequest.of(10, 15, sort));
 
 		verify(opsMock, times(1)).findInRange(eq(150L), eq(15), eq(sort), eq(Foo.class));
 	}

--- a/src/test/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQueryUnitTests.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.data.keyvalue.repository.query;
 
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.core.IsNot.*;
-import static org.hamcrest.core.IsNull.*;
-import static org.hamcrest.core.IsSame.*;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.keyvalue.Person;
@@ -86,7 +87,7 @@ public class KeyValuePartTreeQueryUnitTests {
 		KeyValuePartTreeQuery partTreeQuery = new KeyValuePartTreeQuery(qm, DefaultEvaluationContextProvider.INSTANCE,
 				kvOpsMock, SpelQueryCreator.class);
 
-		KeyValueQuery<?> query = partTreeQuery.prepareQuery(new Object[] { new PageRequest(2, 3) });
+		KeyValueQuery<?> query = partTreeQuery.prepareQuery(new Object[] { PageRequest.of(2, 3) });
 
 		assertThat(query.getOffset(), is(6L));
 		assertThat(query.getRows(), is(3));

--- a/src/test/java/org/springframework/data/keyvalue/repository/query/SpelQueryCreatorUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/query/SpelQueryCreatorUnitTests.java
@@ -72,32 +72,32 @@ public class SpelQueryCreatorUnitTests {
 	}
 
 	@Test // DATACMNS-525
-	public void isTrueAssertedPropertlyWhenTrue() throws Exception {
+	public void isTrueAssertedProperlyWhenTrue() throws Exception {
 		assertThat(evaluate("findBySkinChangerIsTrue").against(BRAN), is(true));
 	}
 
 	@Test // DATACMNS-525
-	public void isTrueAssertedPropertlyWhenFalse() throws Exception {
+	public void isTrueAssertedProperlyWhenFalse() throws Exception {
 		assertThat(evaluate("findBySkinChangerIsTrue").against(RICKON), is(false));
 	}
 
 	@Test // DATACMNS-525
-	public void isFalseAssertedPropertlyWhenTrue() throws Exception {
+	public void isFalseAssertedProperlyWhenTrue() throws Exception {
 		assertThat(evaluate("findBySkinChangerIsFalse").against(BRAN), is(false));
 	}
 
 	@Test // DATACMNS-525
-	public void isFalseAssertedPropertlyWhenFalse() throws Exception {
+	public void isFalseAssertedProperlyWhenFalse() throws Exception {
 		assertThat(evaluate("findBySkinChangerIsFalse").against(RICKON), is(true));
 	}
 
 	@Test // DATACMNS-525
-	public void isNullAssertedPropertlyWhenAttributeIsNull() throws Exception {
+	public void isNullAssertedProperlyWhenAttributeIsNull() throws Exception {
 		assertThat(evaluate("findByLastnameIsNull").against(BRAN), is(true));
 	}
 
 	@Test // DATACMNS-525
-	public void isNullAssertedPropertlyWhenAttributeIsNotNull() throws Exception {
+	public void isNullAssertedProperlyWhenAttributeIsNotNull() throws Exception {
 		assertThat(evaluate("findByLastnameIsNull").against(ROBB), is(false));
 	}
 
@@ -400,8 +400,8 @@ public class SpelQueryCreatorUnitTests {
 		SpelExpression expression;
 		Object candidate;
 
-		public Evaluation(SpelExpression expresison) {
-			this.expression = expresison;
+		public Evaluation(SpelExpression expression) {
+			this.expression = expression;
 		}
 
 		public Boolean against(Object candidate) {

--- a/src/test/java/org/springframework/data/keyvalue/repository/query/SpelQueryCreatorUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/query/SpelQueryCreatorUnitTests.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Date;
 
 import org.joda.time.format.DateTimeFormatter;
@@ -260,6 +261,51 @@ public class SpelQueryCreatorUnitTests {
 		assertThat(evaluate("findByLastnameMatches", "^s.*w$").against(ROBB), is(false));
 	}
 
+	@Test // DATAKV-169
+	public void inReturnsMatchCorrectly() throws Exception {
+
+		ArrayList<String> list = new ArrayList<>();
+		list.add(ROBB.firstname);
+
+		assertThat(evaluate("findByFirstnameIn", list).against(ROBB), is(true));
+	}
+
+	@Test // DATAKV-169
+	public void inNotMatchingReturnsCorrectly() throws Exception {
+
+		ArrayList<String> list = new ArrayList<>();
+		list.add(ROBB.firstname);
+
+		assertThat(evaluate("findByFirstnameIn", list).against(JON), is(false));
+	}
+
+	@Test // DATAKV-169
+	public void inWithNullCompareValuesCorrectly() throws Exception {
+
+		ArrayList<String> list = new ArrayList<>();
+		list.add(null);
+
+		assertThat(evaluate("findByFirstnameIn", list).against(JON), is(false));
+	}
+
+	@Test // DATAKV-169
+	public void inWithNullSourceValuesMatchesCorrectly() throws Exception {
+
+		ArrayList<String> list = new ArrayList<>();
+		list.add(ROBB.firstname);
+
+		assertThat(evaluate("findByFirstnameIn", list).against(new Person(null, 10)), is(false));
+	}
+
+	@Test // DATAKV-169
+	public void inMatchesNullValuesCorrectly() throws Exception {
+
+		ArrayList<String> list = new ArrayList<>();
+		list.add(null);
+
+		assertThat(evaluate("findByFirstnameIn", list).against(new Person(null, 10)), is(true));
+	}
+
 	private Evaluation evaluate(String methodName, Object... args) throws Exception {
 		return new Evaluation((SpelExpression) createQueryForMethodWithArgs(methodName, args).getCritieria());
 	}
@@ -343,6 +389,9 @@ public class SpelQueryCreatorUnitTests {
 
 		// Type.REGEX
 		Person findByLastnameMatches(String lastname);
+
+		// Type.IN
+		Person findByFirstnameIn(ArrayList<String> in);
 
 	}
 

--- a/src/test/java/org/springframework/data/keyvalue/repository/support/KeyValueQuerydslUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/support/KeyValueQuerydslUtilsUnitTests.java
@@ -15,13 +15,14 @@
  */
 package org.springframework.data.keyvalue.repository.support;
 
-import static org.hamcrest.collection.IsArrayWithSize.*;
-import static org.junit.Assert.*;
-import static org.springframework.data.keyvalue.repository.support.KeyValueQuerydslUtils.*;
+import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
+import static org.junit.Assert.assertThat;
+import static org.springframework.data.keyvalue.repository.support.KeyValueQuerydslUtils.toOrderSpecifier;
 
 import org.hamcrest.collection.IsArrayContainingInOrder;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.NullHandling;
@@ -35,7 +36,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
 
 /**
  * Unit tests for {@link KeyValueQuerydslUtils}.
- * 
+ *
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Oliver Gierke
@@ -49,12 +50,12 @@ public class KeyValueQuerydslUtilsUnitTests {
 	public void setUp() {
 
 		this.path = SimpleEntityPathResolver.INSTANCE.createPath(Person.class);
-		this.builder = new PathBuilder<Person>(path.getType(), path.getMetadata());
+		this.builder = new PathBuilder<>(path.getType(), path.getMetadata());
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATACMNS-525
 	public void toOrderSpecifierThrowsExceptioOnNullPathBuilder() {
-		toOrderSpecifier(new Sort("firstname"), null);
+		toOrderSpecifier(Sort.by("firstname"), null);
 	}
 
 	@Test // DATACMNS-525
@@ -65,7 +66,7 @@ public class KeyValueQuerydslUtilsUnitTests {
 	@Test // DATACMNS-525
 	public void toOrderSpecifierConvertsSimpleAscSortCorrectly() {
 
-		Sort sort = new Sort(Direction.ASC, "firstname");
+		Sort sort = Sort.by(Direction.ASC, "firstname");
 
 		OrderSpecifier<?>[] specifiers = toOrderSpecifier(sort, builder);
 
@@ -76,7 +77,7 @@ public class KeyValueQuerydslUtilsUnitTests {
 	@Test // DATACMNS-525
 	public void toOrderSpecifierConvertsSimpleDescSortCorrectly() {
 
-		Sort sort = new Sort(Direction.DESC, "firstname");
+		Sort sort = Sort.by(Direction.DESC, "firstname");
 
 		OrderSpecifier<?>[] specifiers = toOrderSpecifier(sort, builder);
 
@@ -87,7 +88,7 @@ public class KeyValueQuerydslUtilsUnitTests {
 	@Test // DATACMNS-525
 	public void toOrderSpecifierConvertsSortCorrectlyAndRetainsArgumentOrder() {
 
-		Sort sort = new Sort(Direction.DESC, "firstname").and(new Sort(Direction.ASC, "age"));
+		Sort sort = Sort.by(Direction.DESC, "firstname").and(Sort.by(Direction.ASC, "age"));
 
 		OrderSpecifier<?>[] specifiers = toOrderSpecifier(sort, builder);
 
@@ -98,7 +99,7 @@ public class KeyValueQuerydslUtilsUnitTests {
 	@Test // DATACMNS-525
 	public void toOrderSpecifierConvertsSortWithNullHandlingCorrectly() {
 
-		Sort sort = new Sort(new Sort.Order(Direction.DESC, "firstname", NullHandling.NULLS_LAST));
+		Sort sort = Sort.by(new Sort.Order(Direction.DESC, "firstname", NullHandling.NULLS_LAST));
 
 		OrderSpecifier<?>[] specifiers = toOrderSpecifier(sort, builder);
 

--- a/src/test/java/org/springframework/data/map/AbstractRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/map/AbstractRepositoryUnitTests.java
@@ -168,13 +168,51 @@ public abstract class AbstractRepositoryUnitTests<T extends AbstractRepositoryUn
 		assertThat(result.get(0).getFirstname(), is(CERSEI.getFirstname()));
 	}
 
+	@Test // DATAKV-169
+	public void findsByValueInCollectionCorrectly() {
+
+		repository.save(LENNISTERS);
+
+		List<Person> result = repository.findByFirstnameIn(Arrays.asList(CERSEI.getFirstname(), JAIME.getFirstname()));
+
+		assertThat(result, hasSize(2));
+		assertThat(result, is(containsInAnyOrder(CERSEI, JAIME)));
+	}
+
+	@Test // DATAKV-169
+	public void findsByValueInCollectionCorrectlyWhenTargetPathContainsNullValue() {
+
+		repository.save(LENNISTERS);
+		repository.save(new Person(null, 10));
+
+		List<Person> result = repository.findByFirstnameIn(Arrays.asList(CERSEI.getFirstname(), JAIME.getFirstname()));
+
+		assertThat(result, hasSize(2));
+		assertThat(result, is(containsInAnyOrder(CERSEI, JAIME)));
+	}
+
+	@Test // DATAKV-169
+	public void findsByValueInCollectionCorrectlyWhenTargetPathAndCollectionContainNullValue() {
+
+		repository.save(LENNISTERS);
+
+		Person personWithNullAsFirstname = new Person(null, 10);
+		repository.save(personWithNullAsFirstname);
+
+		List<Person> result = repository
+				.findByFirstnameIn(Arrays.asList(CERSEI.getFirstname(), JAIME.getFirstname(), null));
+
+		assertThat(result, hasSize(3));
+		assertThat(result, is(containsInAnyOrder(CERSEI, JAIME, personWithNullAsFirstname)));
+	}
+
 	protected KeyValueRepositoryFactory createKeyValueRepositoryFactory(KeyValueOperations operations) {
 		return new KeyValueRepositoryFactory(operations);
 	}
 
 	protected abstract T getRepository(KeyValueRepositoryFactory factory);
 
-	public static interface PersonRepository extends CrudRepository<Person, String>, KeyValueRepository<Person, String> {
+	public interface PersonRepository extends CrudRepository<Person, String>, KeyValueRepository<Person, String> {
 
 		List<Person> findByAge(int age);
 
@@ -193,6 +231,8 @@ public abstract class AbstractRepositoryUnitTests<T extends AbstractRepositoryUn
 		List<PersonSummary> findByAgeGreaterThan(int age, Sort sort);
 
 		<T> List<T> findByAgeGreaterThan(int age, Sort sort, Class<T> projectionType);
+
+		List<Person> findByFirstnameIn(List<String> firstname);
 	}
 
 	interface PersonSummary {

--- a/src/test/java/org/springframework/data/map/AbstractRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/map/AbstractRepositoryUnitTests.java
@@ -15,8 +15,13 @@
  */
 package org.springframework.data.map;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +29,7 @@ import java.util.List;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -39,7 +45,7 @@ import org.springframework.data.repository.CrudRepository;
 
 /**
  * Base class for test cases for repository implementations.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Thomas Darimont
@@ -98,7 +104,7 @@ public abstract class AbstractRepositoryUnitTests<T extends AbstractRepositoryUn
 
 		repository.save(LENNISTERS);
 
-		Page<Person> page = repository.findByAge(19, new PageRequest(0, 1));
+		Page<Person> page = repository.findByAge(19, PageRequest.of(0, 1));
 		assertThat(page.hasNext(), is(true));
 		assertThat(page.getTotalElements(), is(2L));
 		assertThat(page.getContent(), IsCollectionWithSize.hasSize(1));
@@ -132,7 +138,7 @@ public abstract class AbstractRepositoryUnitTests<T extends AbstractRepositoryUn
 		repository.save(LENNISTERS);
 
 		assertThat(
-				repository.findAll(new Sort(new Sort.Order(Direction.ASC, "age"), new Sort.Order(Direction.DESC, "firstname"))),
+				repository.findAll(Sort.by(new Sort.Order(Direction.ASC, "age"), new Sort.Order(Direction.DESC, "firstname"))),
 				contains(TYRION, JAIME, CERSEI));
 	}
 
@@ -151,7 +157,7 @@ public abstract class AbstractRepositoryUnitTests<T extends AbstractRepositoryUn
 
 		repository.save(LENNISTERS);
 
-		List<PersonSummary> result = repository.findByAgeGreaterThan(0, new Sort("firstname"));
+		List<PersonSummary> result = repository.findByAgeGreaterThan(0, Sort.by("firstname"));
 
 		assertThat(result, hasSize(3));
 		assertThat(result.get(0).getFirstname(), is(CERSEI.getFirstname()));
@@ -162,7 +168,7 @@ public abstract class AbstractRepositoryUnitTests<T extends AbstractRepositoryUn
 
 		repository.save(LENNISTERS);
 
-		List<PersonSummary> result = repository.findByAgeGreaterThan(0, new Sort("firstname"), PersonSummary.class);
+		List<PersonSummary> result = repository.findByAgeGreaterThan(0, Sort.by("firstname"), PersonSummary.class);
 
 		assertThat(result, hasSize(3));
 		assertThat(result.get(0).getFirstname(), is(CERSEI.getFirstname()));

--- a/src/test/java/org/springframework/data/map/QuerydslKeyValueRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/map/QuerydslKeyValueRepositoryUnitTests.java
@@ -15,12 +15,17 @@
  */
 package org.springframework.data.map;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
 import org.junit.Test;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -37,7 +42,7 @@ import com.google.common.collect.Lists;
 
 /**
  * Unit tests for {@link QuerydslKeyValueRepository}.
- * 
+ *
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Thomas Darimont
@@ -66,7 +71,7 @@ public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitT
 	public void findWithPaginationWorksCorrectly() {
 
 		repository.save(LENNISTERS);
-		Page<Person> page1 = repository.findAll(QPerson.person.age.eq(CERSEI.getAge()), new PageRequest(0, 1));
+		Page<Person> page1 = repository.findAll(QPerson.person.age.eq(CERSEI.getAge()), PageRequest.of(0, 1));
 
 		assertThat(page1.getTotalElements(), is(2L));
 		assertThat(page1.getContent(), hasSize(1));
@@ -96,7 +101,8 @@ public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitT
 
 		repository.save(LENNISTERS);
 
-		Iterable<Person> result = repository.findAll(QPerson.person.age.eq(CERSEI.getAge()), new PageRequest(0, 10,
+		Iterable<Person> result = repository.findAll(QPerson.person.age.eq(CERSEI.getAge()),
+				PageRequest.of(0, 10,
 				Direction.DESC, "firstname"));
 
 		assertThat(result, contains(JAIME, CERSEI));
@@ -107,7 +113,8 @@ public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitT
 
 		repository.save(LENNISTERS);
 
-		Iterable<Person> result = repository.findAll(QPerson.person.age.eq(CERSEI.getAge()), new PageRequest(0, 10,
+		Iterable<Person> result = repository.findAll(QPerson.person.age.eq(CERSEI.getAge()),
+				PageRequest.of(0, 10,
 				new QSort(QPerson.person.firstname.desc())));
 
 		assertThat(result, contains(JAIME, CERSEI));
@@ -146,7 +153,7 @@ public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitT
 
 		repository.save(LENNISTERS);
 
-		List<Person> users = Lists.newArrayList(repository.findAll(person.age.gt(0), new Sort(Direction.ASC, "firstname")));
+		List<Person> users = Lists.newArrayList(repository.findAll(person.age.gt(0), Sort.by(Direction.ASC, "firstname")));
 
 		assertThat(users, hasSize(3));
 		assertThat(users.get(0).getFirstname(), is(CERSEI.getFirstname()));
@@ -154,7 +161,7 @@ public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitT
 		assertThat(users, hasItems(CERSEI, JAIME, TYRION));
 	}
 
-	/* 
+	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.map.SimpleKeyValueRepositoryUnitTests#getRepository(org.springframework.data.keyvalue.repository.support.KeyValueRepositoryFactory)
 	 */


### PR DESCRIPTION
We now support `In` keyword in derived finder methods (eg. `findByFirstnameIn(Collection<String> firstnames)`) when using SpEL based queries.