### PR TITLE
DATAKV - 186 : Incorrect behavior of SimpleKeyValueRepository.existsById(…) due to changes with Optional

### DIFF
--- a/src/main/java/org/springframework/data/keyvalue/repository/support/SimpleKeyValueRepository.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/SimpleKeyValueRepository.java
@@ -132,7 +132,7 @@ public class SimpleKeyValueRepository<T, ID extends Serializable> implements Key
 	 */
 	@Override
 	public boolean existsById(ID id) {
-		return findById(id) != null;
+		return findById(id).isPresent();
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/keyvalue/repository/SimpleKeyValueRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/SimpleKeyValueRepositoryUnitTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.keyvalue.repository;
 
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -122,6 +123,17 @@ public class SimpleKeyValueRepositoryUnitTests {
 		repo.findAllById(Arrays.asList("one", "two", "three"));
 
 		verify(opsMock, times(3)).findById(anyString(), eq(Foo.class));
+	}
+
+	@Test // DATAKV-186
+	public void existsById() {
+		when(opsMock.findById(any(Serializable.class), any(Class.class))).thenReturn(Optional.empty());
+		assertFalse(repo.existsById("one"));
+
+		when(opsMock.findById(any(Serializable.class), any(Class.class))).thenReturn(Optional.of(new Foo()));
+		assertTrue(repo.existsById("one"));
+
+		verify(opsMock, times(2)).findById(anyString(), eq(Foo.class));
 	}
 
 	@Test // DATACMNS-525


### PR DESCRIPTION
Fix incorrect null lookup on existsById method. Provide test for different method behavior on findById's results