### PR TITLE
DATAKV-196 - Open up configuration and repository components for extension.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAKV-196-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/core/SpelSortAccessor.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SpelSortAccessor.java
@@ -32,14 +32,16 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Mark Paluch
  */
-class SpelSortAccessor implements SortAccessor<Comparator<?>> {
+public class SpelSortAccessor implements SortAccessor<Comparator<?>> {
 
 	private final SpelExpressionParser parser;
 
 	/**
+	 * Creates a new {@link SpelSortAccessor} given {@link SpelExpressionParser}.
+	 *
 	 * @param parser must not be {@literal null}.
 	 */
-	SpelSortAccessor(SpelExpressionParser parser) {
+	public SpelSortAccessor(SpelExpressionParser parser) {
 
 		Assert.notNull(parser, "SpelExpressionParser must not be null!");
 		this.parser = parser;

--- a/src/main/java/org/springframework/data/keyvalue/repository/config/KeyValueRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/config/KeyValueRepositoryConfigurationExtension.java
@@ -42,6 +42,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public abstract class KeyValueRepositoryConfigurationExtension extends RepositoryConfigurationExtensionSupport {
 
@@ -96,7 +97,7 @@ public abstract class KeyValueRepositoryConfigurationExtension extends Repositor
 		builder.addPropertyReference("keyValueOperations", attributes.getString(KEY_VALUE_TEMPLATE_BEAN_REF_ATTRIBUTE));
 		builder.addPropertyValue("queryCreator", getQueryCreatorType(config));
 		builder.addPropertyValue("queryType", getQueryType(config));
-		builder.addPropertyReference("mappingContext", MAPPING_CONTEXT_BEAN_NAME);
+		builder.addPropertyReference("mappingContext", getMappingContextBeanRef());
 	}
 
 	/**
@@ -155,7 +156,7 @@ public abstract class KeyValueRepositoryConfigurationExtension extends Repositor
 		RootBeanDefinition mappingContextDefinition = new RootBeanDefinition(KeyValueMappingContext.class);
 		mappingContextDefinition.setSource(configurationSource.getSource());
 
-		registerIfNotAlreadyRegistered(mappingContextDefinition, registry, MAPPING_CONTEXT_BEAN_NAME, configurationSource);
+		registerIfNotAlreadyRegistered(mappingContextDefinition, registry, getMappingContextBeanRef(), configurationSource);
 
 		Optional<String> keyValueTemplateName = configurationSource.getAttribute(KEY_VALUE_TEMPLATE_BEAN_REF_ATTRIBUTE);
 
@@ -176,11 +177,32 @@ public abstract class KeyValueRepositoryConfigurationExtension extends Repositor
 	 * Get the default {@link RootBeanDefinition} for {@link org.springframework.data.keyvalue.core.KeyValueTemplate}.
 	 *
 	 * @return {@literal null} to explicitly not register a template.
+	 * @see #getDefaultKeyValueTemplateRef()
 	 */
 	protected AbstractBeanDefinition getDefaultKeyValueTemplateBeanDefinition(
 			RepositoryConfigurationSource configurationSource) {
 		return null;
 	}
 
+	/**
+	 * Returns the {@link org.springframework.data.keyvalue.core.KeyValueTemplate} bean name to potentially register a
+	 * default {@link org.springframework.data.keyvalue.core.KeyValueTemplate} bean if no bean is registered with the
+	 * returned name.
+	 * 
+	 * @return the default {@link org.springframework.data.keyvalue.core.KeyValueTemplate} bean name.
+	 * @see #getDefaultKeyValueTemplateBeanDefinition(RepositoryConfigurationSource)
+	 */
 	protected abstract String getDefaultKeyValueTemplateRef();
+
+	/**
+	 * Returns the {@link org.springframework.data.mapping.context.MappingContext} bean name to potentially register a
+	 * default mapping context bean if no bean is registered with the returned name. Defaults to
+	 * {@link MAPPING_CONTEXT_BEAN_NAME}.
+	 * 
+	 * @return the {@link org.springframework.data.mapping.context.MappingContext} bean name.
+	 * @since 2.0
+	 */
+	protected String getMappingContextBeanRef() {
+		return MAPPING_CONTEXT_BEAN_NAME;
+	}
 }

--- a/src/main/java/org/springframework/data/keyvalue/repository/config/KeyValueRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/config/KeyValueRepositoryConfigurationExtension.java
@@ -35,6 +35,7 @@ import org.springframework.data.repository.config.AnnotationRepositoryConfigurat
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
+import org.springframework.lang.Nullable;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -104,7 +105,7 @@ public abstract class KeyValueRepositoryConfigurationExtension extends Repositor
 	 * Detects the query creator type to be used for the factory to set. Will lookup a {@link QueryCreatorType} annotation
 	 * on the {@code @Enable}-annotation or use {@link SpelQueryCreator} if not found.
 	 *
-	 * @param config
+	 * @param config must not be {@literal null}.
 	 * @return
 	 */
 	private static Class<?> getQueryCreatorType(AnnotationRepositoryConfigurationSource config) {
@@ -179,6 +180,7 @@ public abstract class KeyValueRepositoryConfigurationExtension extends Repositor
 	 * @return {@literal null} to explicitly not register a template.
 	 * @see #getDefaultKeyValueTemplateRef()
 	 */
+	@Nullable
 	protected AbstractBeanDefinition getDefaultKeyValueTemplateBeanDefinition(
 			RepositoryConfigurationSource configurationSource) {
 		return null;
@@ -188,8 +190,9 @@ public abstract class KeyValueRepositoryConfigurationExtension extends Repositor
 	 * Returns the {@link org.springframework.data.keyvalue.core.KeyValueTemplate} bean name to potentially register a
 	 * default {@link org.springframework.data.keyvalue.core.KeyValueTemplate} bean if no bean is registered with the
 	 * returned name.
-	 * 
-	 * @return the default {@link org.springframework.data.keyvalue.core.KeyValueTemplate} bean name.
+	 *
+	 * @return the default {@link org.springframework.data.keyvalue.core.KeyValueTemplate} bean name. Never
+	 *         {@literal null}.
 	 * @see #getDefaultKeyValueTemplateBeanDefinition(RepositoryConfigurationSource)
 	 */
 	protected abstract String getDefaultKeyValueTemplateRef();
@@ -198,8 +201,8 @@ public abstract class KeyValueRepositoryConfigurationExtension extends Repositor
 	 * Returns the {@link org.springframework.data.mapping.context.MappingContext} bean name to potentially register a
 	 * default mapping context bean if no bean is registered with the returned name. Defaults to
 	 * {@link MAPPING_CONTEXT_BEAN_NAME}.
-	 * 
-	 * @return the {@link org.springframework.data.mapping.context.MappingContext} bean name.
+	 *
+	 * @return the {@link org.springframework.data.mapping.context.MappingContext} bean name. Never {@literal null}.
 	 * @since 2.0
 	 */
 	protected String getMappingContextBeanRef() {

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
@@ -175,18 +175,42 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 		throw new IllegalStateException(String.format("Cannot retrieve SpelExpression from %s", criteria));
 	}
 
+	/**
+	 * Create a {@link KeyValueQuery} given {@link ParameterAccessor}.
+	 *
+	 * @param accessor must not be {@literal null}.
+	 * @return the {@link KeyValueQuery}.
+	 */
 	public KeyValueQuery<?> createQuery(ParameterAccessor accessor) {
 
 		PartTree tree = new PartTree(getQueryMethod().getName(), getQueryMethod().getEntityInformation().getJavaType());
 
-		Constructor<? extends AbstractQueryCreator<?, ?>> constructor = ClassUtils
-				.getConstructorIfAvailable(queryCreator, PartTree.class, ParameterAccessor.class);
-		KeyValueQuery<?> query = (KeyValueQuery<?>) BeanUtils.instantiateClass(constructor, tree, accessor).createQuery();
+		AbstractQueryCreator<? extends KeyValueQuery<?>, ?> queryCreator = createQueryCreator(tree, accessor);
+
+		KeyValueQuery<?> query = queryCreator.createQuery();
 
 		if (tree.isLimiting()) {
 			query.setRows(tree.getMaxResults());
 		}
 		return query;
+	}
+
+	/**
+	 * Constructs a {@link AbstractQueryCreator} for repository query creation. Subclasses may override this method to
+	 * customize query creator construction.
+	 *
+	 * @param tree must not be {@literal null}.
+	 * @param accessor must not be {@literal null}.
+	 * @return the {@link AbstractQueryCreator} object.
+	 * @since 2.0
+	 */
+	protected AbstractQueryCreator<? extends KeyValueQuery<?>, ?> createQueryCreator(PartTree tree,
+			ParameterAccessor accessor) {
+
+		Constructor<? extends AbstractQueryCreator<?, ?>> constructor = ClassUtils.getConstructorIfAvailable(queryCreator,
+				PartTree.class, ParameterAccessor.class);
+
+		return (AbstractQueryCreator<KeyValueQuery<?>, ?>) BeanUtils.instantiateClass(constructor, tree, accessor);
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
@@ -35,6 +35,7 @@ import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -51,7 +52,7 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 	private final EvaluationContextProvider evaluationContextProvider;
 	private final QueryMethod queryMethod;
 	private final KeyValueOperations keyValueOperations;
-	private final Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
+	private final QueryCreatorFactory<AbstractQueryCreator<KeyValueQuery<?>, ?>> queryCreatorFactory;
 
 	/**
 	 * Creates a new {@link KeyValuePartTreeQuery} for the given {@link QueryMethod}, {@link EvaluationContextProvider},
@@ -65,15 +66,33 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 	public KeyValuePartTreeQuery(QueryMethod queryMethod, EvaluationContextProvider evaluationContextProvider,
 			KeyValueOperations keyValueOperations, Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
 
+		this(queryMethod, evaluationContextProvider, keyValueOperations,
+				new ConstructorCachingQueryCreatorFactory(queryCreator));
+	}
+
+	/**
+	 * Creates a new {@link KeyValuePartTreeQuery} for the given {@link QueryMethod}, {@link EvaluationContextProvider},
+	 * {@link KeyValueOperations} using the given {@link QueryCreatorFactory} producing the {@link AbstractQueryCreator}
+	 * in charge of altering the query.
+	 *
+	 * @param queryMethod must not be {@literal null}.
+	 * @param evaluationContextProvider must not be {@literal null}.
+	 * @param keyValueOperations must not be {@literal null}.
+	 * @param queryCreatorFactory must not be {@literal null}.
+	 * @since 2.0
+	 */
+	public KeyValuePartTreeQuery(QueryMethod queryMethod, EvaluationContextProvider evaluationContextProvider,
+			KeyValueOperations keyValueOperations, QueryCreatorFactory queryCreatorFactory) {
+
 		Assert.notNull(queryMethod, "Query method must not be null!");
 		Assert.notNull(evaluationContextProvider, "EvaluationContextprovider must not be null!");
 		Assert.notNull(keyValueOperations, "KeyValueOperations must not be null!");
-		Assert.notNull(queryCreator, "QueryCreator type must not be null!");
+		Assert.notNull(queryCreatorFactory, "QueryCreatorFactory type must not be null!");
 
 		this.queryMethod = queryMethod;
 		this.keyValueOperations = keyValueOperations;
 		this.evaluationContextProvider = evaluationContextProvider;
-		this.queryCreator = queryCreator;
+		this.queryCreatorFactory = queryCreatorFactory;
 	}
 
 	/*
@@ -185,7 +204,8 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 
 		PartTree tree = new PartTree(getQueryMethod().getName(), getQueryMethod().getEntityInformation().getJavaType());
 
-		AbstractQueryCreator<? extends KeyValueQuery<?>, ?> queryCreator = createQueryCreator(tree, accessor);
+		AbstractQueryCreator<? extends KeyValueQuery<?>, ?> queryCreator = queryCreatorFactory.queryCreatorFor(tree,
+				accessor);
 
 		KeyValueQuery<?> query = queryCreator.createQuery();
 
@@ -195,24 +215,6 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 		return query;
 	}
 
-	/**
-	 * Constructs a {@link AbstractQueryCreator} for repository query creation. Subclasses may override this method to
-	 * customize query creator construction.
-	 *
-	 * @param tree must not be {@literal null}.
-	 * @param accessor must not be {@literal null}.
-	 * @return the {@link AbstractQueryCreator} object.
-	 * @since 2.0
-	 */
-	protected AbstractQueryCreator<? extends KeyValueQuery<?>, ?> createQueryCreator(PartTree tree,
-			ParameterAccessor accessor) {
-
-		Constructor<? extends AbstractQueryCreator<?, ?>> constructor = ClassUtils.getConstructorIfAvailable(queryCreator,
-				PartTree.class, ParameterAccessor.class);
-
-		return (AbstractQueryCreator<KeyValueQuery<?>, ?>) BeanUtils.instantiateClass(constructor, tree, accessor);
-	}
-
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.query.RepositoryQuery#getQueryMethod()
@@ -220,5 +222,45 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 	@Override
 	public QueryMethod getQueryMethod() {
 		return queryMethod;
+	}
+
+	/**
+	 * Factory class for obtaining {@link AbstractQueryCreator} instances for a given {@link PartTree} and
+	 * {@link ParameterAccessor}.
+	 *
+	 * @author Christoph Strobl
+	 * @since 2.0
+	 */
+	public interface QueryCreatorFactory<T extends AbstractQueryCreator> {
+
+		T queryCreatorFor(PartTree partTree, ParameterAccessor accessor);
+	}
+
+	/**
+	 * {@link QueryCreatorFactory} implementation instantiating {@link AbstractQueryCreator} via reflection. Looks up and
+	 * caches the constructor on creation.
+	 *
+	 * @author Christoph Strobl
+	 * @since 2.0
+	 */
+	private static class ConstructorCachingQueryCreatorFactory
+			implements QueryCreatorFactory<AbstractQueryCreator<KeyValueQuery<?>, ?>> {
+
+		private final Class<?> type;
+		private final @Nullable Constructor<? extends AbstractQueryCreator<?, ?>> constructor;
+
+		ConstructorCachingQueryCreatorFactory(Class<? extends AbstractQueryCreator<?, ?>> type) {
+
+			this.type = type;
+			this.constructor = ClassUtils.getConstructorIfAvailable(type, PartTree.class, ParameterAccessor.class);
+		}
+
+		@Override
+		public AbstractQueryCreator<KeyValueQuery<?>, ?> queryCreatorFor(PartTree partTree, ParameterAccessor accessor) {
+
+			Assert.state(constructor != null,
+					() -> String.format("No constructor (PartTree, ParameterAccessor) could be found on type %s!", type));
+			return (AbstractQueryCreator<KeyValueQuery<?>, ?>) BeanUtils.instantiateClass(constructor, partTree, accessor);
+		}
 	}
 }


### PR DESCRIPTION
* Make `SpelSortAccessor` public. 
* Introduce `getMappingContextBeanRef()` template method to `KeyValueRepositoryConfigurationExtension` so subclasses may specify the mapping context bean name. 
* Introduce `createQueryCreator()` template method to `KeyValuePartTreeQuery` for query creator customization in subclasses.

---

Related ticket: [DATAKV-196](https://jira.spring.io/browse/DATAKV-196).