### PR TITLE
DATAKV-197 - Introduce usage of nullable annotations for API validation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAKV-197-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/annotation/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/annotation/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Key-Value annotations for declarative keyspace configuration.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.annotation;

--- a/src/main/java/org/springframework/data/keyvalue/core/AbstractKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/AbstractKeyValueAdapter.java
@@ -18,6 +18,7 @@ package org.springframework.data.keyvalue.core;
 import java.util.Collection;
 
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
+import org.springframework.lang.Nullable;
 
 /**
  * Base implementation of {@link KeyValueAdapter} holds {@link QueryEngine} to delegate {@literal find} and
@@ -42,7 +43,7 @@ public abstract class AbstractKeyValueAdapter implements KeyValueAdapter {
 	 *
 	 * @param engine will be defaulted to {@link SpelQueryEngine} if {@literal null}.
 	 */
-	protected AbstractKeyValueAdapter(QueryEngine<? extends KeyValueAdapter, ?, ?> engine) {
+	protected AbstractKeyValueAdapter(@Nullable QueryEngine<? extends KeyValueAdapter, ?, ?> engine) {
 
 		this.engine = engine != null ? engine : new SpelQueryEngine();
 		this.engine.registerAdapter(this);
@@ -61,6 +62,7 @@ public abstract class AbstractKeyValueAdapter implements KeyValueAdapter {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#get(java.lang.Object, java.lang.String, java.lang.Class)
 	 */
+	@Nullable
 	@Override
 	public <T> T get(Object id, String keyspace, Class<T> type) {
 		return type.cast(get(id, keyspace));
@@ -70,6 +72,7 @@ public abstract class AbstractKeyValueAdapter implements KeyValueAdapter {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.keyvalue.core.KeyValueAdapter#delete(java.lang.Object, java.lang.String, java.lang.Class)
 	 */
+	@Nullable
 	@Override
 	public <T> T delete(Object id, String keyspace, Class<T> type) {
 		return type.cast(delete(id, keyspace));

--- a/src/main/java/org/springframework/data/keyvalue/core/CriteriaAccessor.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/CriteriaAccessor.java
@@ -16,6 +16,7 @@
 package org.springframework.data.keyvalue.core;
 
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
+import org.springframework.lang.Nullable;
 
 /**
  * Resolves the criteria object from given {@link KeyValueQuery}.
@@ -31,9 +32,10 @@ public interface CriteriaAccessor<T> {
 	 * transformation to match the desired type.
 	 *
 	 * @param query must not be {@literal null}.
-	 * @return the criteria extracted from the query.
+	 * @return the criteria extracted from the query. Can be {@literal null}.
 	 * @throws IllegalArgumentException in case the criteria is not valid for usage with specific
 	 *           {@link CriteriaAccessor}.
 	 */
+	@Nullable
 	T resolve(KeyValueQuery<?> query);
 }

--- a/src/main/java/org/springframework/data/keyvalue/core/CriteriaAccessor.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/CriteriaAccessor.java
@@ -21,6 +21,7 @@ import org.springframework.data.keyvalue.core.query.KeyValueQuery;
  * Resolves the criteria object from given {@link KeyValueQuery}.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @param <T>
  */
 public interface CriteriaAccessor<T> {
@@ -29,7 +30,7 @@ public interface CriteriaAccessor<T> {
 	 * Checks and reads {@link KeyValueQuery#getCriteria()} of given {@link KeyValueQuery}. Might also apply additional
 	 * transformation to match the desired type.
 	 *
-	 * @param query can be {@literal null}.
+	 * @param query must not be {@literal null}.
 	 * @return the criteria extracted from the query.
 	 * @throws IllegalArgumentException in case the criteria is not valid for usage with specific
 	 *           {@link CriteriaAccessor}.

--- a/src/main/java/org/springframework/data/keyvalue/core/ForwardingCloseableIterator.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/ForwardingCloseableIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.data.keyvalue.core;
 import java.util.Iterator;
 
 import org.springframework.data.util.CloseableIterator;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -26,13 +27,14 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @param <K>
  * @param <V>
  */
 public class ForwardingCloseableIterator<T> implements CloseableIterator<T> {
 
 	private final Iterator<? extends T> delegate;
-	private final Runnable closeHandler;
+	private final @Nullable Runnable closeHandler;
 
 	/**
 	 * Creates a new {@link ForwardingCloseableIterator}.
@@ -50,7 +52,7 @@ public class ForwardingCloseableIterator<T> implements CloseableIterator<T> {
 	 * @param delegate must not be {@literal null}.
 	 * @param closeHandler may be {@literal null}.
 	 */
-	public ForwardingCloseableIterator(Iterator<? extends T> delegate, Runnable closeHandler) {
+	public ForwardingCloseableIterator(Iterator<? extends T> delegate, @Nullable Runnable closeHandler) {
 
 		Assert.notNull(delegate, "Delegate iterator must not be null!");
 

--- a/src/main/java/org/springframework/data/keyvalue/core/IterableConverter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/IterableConverter.java
@@ -24,6 +24,7 @@ import java.util.List;
  * Converter capable of transforming a given {@link Iterable} into a collection type.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public final class IterableConverter {
 
@@ -36,10 +37,6 @@ public final class IterableConverter {
 	 * @return {@link Collections#emptyList()} when source is {@literal null}.
 	 */
 	public static <T> List<T> toList(Iterable<T> source) {
-
-		if (source == null) {
-			return Collections.emptyList();
-		}
 
 		if (source instanceof List) {
 			return (List<T>) source;

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
@@ -21,12 +21,14 @@ import java.util.Map;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.data.util.CloseableIterator;
+import org.springframework.lang.Nullable;
 
 /**
  * {@link KeyValueAdapter} unifies access and shields the underlying key/value specific implementation.
  * 
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public interface KeyValueAdapter extends DisposableBean {
 
@@ -55,33 +57,41 @@ public interface KeyValueAdapter extends DisposableBean {
 	 * @param keyspace must not be {@literal null}.
 	 * @return {@literal null} in case no matching item exists.
 	 */
+	@Nullable
 	Object get(Object id, String keyspace);
 
 	/**
-	 * @param id
-	 * @param keyspace
-	 * @param type
-	 * @return
+	 * Get the object with given id from keyspace.
+	 * 
+	 * @param id must not be {@literal null}.
+	 * @param keyspace must not be {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @return {@literal null} in case no matching item exists.
 	 * @since 1.1
 	 */
+	@Nullable
 	<T> T get(Object id, String keyspace, Class<T> type);
 
 	/**
-	 * Delete and return the obect with given type and id.
+	 * Delete and return the object with given type and id.
 	 * 
 	 * @param id must not be {@literal null}.
 	 * @param keyspace must not be {@literal null}.
 	 * @return {@literal null} if object could not be found
 	 */
+	@Nullable
 	Object delete(Object id, String keyspace);
 
 	/**
-	 * @param id
-	 * @param keyspace
-	 * @param type
-	 * @return
+	 * Delete and return the object with given type and id.
+	 * 
+	 * @param id must not be {@literal null}.
+	 * @param keyspace must not be {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @return {@literal null} if object could not be found
 	 * @since 1.1
 	 */
+	@Nullable
 	<T> T delete(Object id, String keyspace, Class<T> type);
 
 	/**
@@ -95,7 +105,7 @@ public interface KeyValueAdapter extends DisposableBean {
 	/**
 	 * Returns a {@link CloseableIterator} that iterates over all entries.
 	 * 
-	 * @param keyspace
+	 * @param keyspace must not be {@literal null}.
 	 * @return
 	 */
 	CloseableIterator<Map.Entry<Object, Object>> entries(String keyspace);
@@ -115,17 +125,17 @@ public interface KeyValueAdapter extends DisposableBean {
 	/**
 	 * Find all matching objects within {@literal keyspace}.
 	 * 
-	 * @param query
+	 * @param query must not be {@literal null}.
 	 * @param keyspace must not be {@literal null}.
 	 * @return empty {@link Collection} if no match found.
 	 */
 	Iterable<?> find(KeyValueQuery<?> query, String keyspace);
 
 	/**
-	 * @param query
-	 * @param keyspace
-	 * @param type
-	 * @return
+	 * @param query must not be {@literal null}.
+	 * @param keyspace must not be {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @return empty {@link Collection} if no match found.
 	 * @since 1.1
 	 */
 	<T> Iterable<T> find(KeyValueQuery<?> query, String keyspace, Class<T> type);
@@ -134,13 +144,14 @@ public interface KeyValueAdapter extends DisposableBean {
 	 * Count number of objects within {@literal keyspace}.
 	 * 
 	 * @param keyspace must not be {@literal null}.
+	 * @return
 	 */
 	long count(String keyspace);
 
 	/**
 	 * Count all matching objects within {@literal keyspace}.
 	 * 
-	 * @param query
+	 * @param query must not be {@literal null}.
 	 * @param keyspace must not be {@literal null}.
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueCallback.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 package org.springframework.data.keyvalue.core;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Generic callback interface for code that operates on a {@link KeyValueAdapter}. This is particularly useful for
  * delegating code that needs to work closely on the underlying key/value store implementation.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @param <T>
  */
 public interface KeyValueCallback<T> {
@@ -31,5 +34,6 @@ public interface KeyValueCallback<T> {
 	 * @param adapter
 	 * @return
 	 */
+	@Nullable
 	T doInKeyValue(KeyValueAdapter adapter);
 }

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueOperations.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueOperations.java
@@ -22,11 +22,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.keyvalue.annotation.KeySpace;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.lang.Nullable;
 
 /**
  * Interface that specifies a basic set of key/value operations. Implemented by {@link KeyValueTemplate}.
  *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface KeyValueOperations extends DisposableBean {
 
@@ -81,6 +83,7 @@ public interface KeyValueOperations extends DisposableBean {
 	 * @param action must not be {@literal null}.
 	 * @return
 	 */
+	@Nullable
 	<T> T execute(KeyValueCallback<T> action);
 
 	/**
@@ -139,6 +142,7 @@ public interface KeyValueOperations extends DisposableBean {
 	 * @param objectToDelete must not be {@literal null}.
 	 * @return
 	 */
+	@Nullable
 	<T> T delete(T objectToDelete);
 
 	/**
@@ -148,6 +152,7 @@ public interface KeyValueOperations extends DisposableBean {
 	 * @param type must not be {@literal null}.
 	 * @return the deleted item or {@literal null} if no match found.
 	 */
+	@Nullable
 	<T> T delete(Object id, Class<T> type);
 
 	/**

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValuePersistenceExceptionTranslator.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValuePersistenceExceptionTranslator.java
@@ -20,6 +20,7 @@ import java.util.NoSuchElementException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.util.Assert;
  * exception to an appropriate exception from the {@code org.springframework.dao} hierarchy.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class KeyValuePersistenceExceptionTranslator implements PersistenceExceptionTranslator {
 
@@ -34,6 +36,7 @@ public class KeyValuePersistenceExceptionTranslator implements PersistenceExcept
 	 * (non-Javadoc)
 	 * @see org.springframework.dao.support.PersistenceExceptionTranslator#translateExceptionIfPossible(java.lang.RuntimeException)
 	 */
+	@Nullable
 	@Override
 	public DataAccessException translateExceptionIfPossible(RuntimeException exception) {
 
@@ -51,6 +54,7 @@ public class KeyValuePersistenceExceptionTranslator implements PersistenceExcept
 		if (exception.getClass().getName().startsWith("java")) {
 			return new UncategorizedKeyValueException(exception.getMessage(), exception);
 		}
+
 		return null;
 	}
 }

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
@@ -348,7 +348,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 
 	/**
 	 * Execute {@link KeyValueCallback} and require a non-{@literal null} return value.
-	 * 
+	 *
 	 * @param action
 	 * @param <T>
 	 * @return

--- a/src/main/java/org/springframework/data/keyvalue/core/SortAccessor.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SortAccessor.java
@@ -17,6 +17,7 @@ package org.springframework.data.keyvalue.core;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
+import org.springframework.lang.Nullable;
 
 /**
  * Resolves the {@link Sort} object from given {@link KeyValueQuery} and potentially converts it into a store specific
@@ -35,5 +36,6 @@ public interface SortAccessor<T> {
 	 * @param query must not be {@literal null}.
 	 * @return {@literal null} in case {@link Sort} has not been defined on {@link KeyValueQuery}.
 	 */
+	@Nullable
 	T resolve(KeyValueQuery<?> query);
 }

--- a/src/main/java/org/springframework/data/keyvalue/core/SortAccessor.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SortAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.data.keyvalue.core.query.KeyValueQuery;
  * representation that can be used by the {@link QueryEngine} implementation.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @param <T>
  */
 public interface SortAccessor<T> {
@@ -31,7 +32,7 @@ public interface SortAccessor<T> {
 	 * Reads {@link KeyValueQuery#getSort()} of given {@link KeyValueQuery} and applies required transformation to match
 	 * the desired type.
 	 * 
-	 * @param query can be {@literal null}.
+	 * @param query must not be {@literal null}.
 	 * @return {@literal null} in case {@link Sort} has not been defined on {@link KeyValueQuery}.
 	 */
 	T resolve(KeyValueQuery<?> query);

--- a/src/main/java/org/springframework/data/keyvalue/core/SpelQueryEngine.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SpelQueryEngine.java
@@ -52,7 +52,7 @@ class SpelQueryEngine extends QueryEngine<KeyValueAdapter, SpelCriteria, Compara
 	 * @see org.springframework.data.keyvalue.core.QueryEngine#execute(java.lang.Object, java.lang.Object, int, int, java.lang.String)
 	 */
 	@Override
-	public Collection<?> execute(SpelCriteria criteria, Comparator<?> sort, long offset, int rows, String keyspace) {
+	public Collection<?> execute(@Nullable SpelCriteria criteria, @Nullable Comparator<?> sort, long offset, int rows, String keyspace) {
 		return sortAndFilterMatchingRange(getRequiredAdapter().getAllOf(keyspace), criteria, sort, offset, rows);
 	}
 
@@ -61,13 +61,13 @@ class SpelQueryEngine extends QueryEngine<KeyValueAdapter, SpelCriteria, Compara
 	 * @see org.springframework.data.keyvalue.core.QueryEngine#count(java.lang.Object, java.lang.String)
 	 */
 	@Override
-	public long count(SpelCriteria criteria, String keyspace) {
+	public long count(@Nullable SpelCriteria criteria, String keyspace) {
 		return filterMatchingRange(IterableConverter.toList(getRequiredAdapter().getAllOf(keyspace)), criteria, -1, -1)
 				.size();
 	}
 
 	@SuppressWarnings("unchecked")
-	private List<?> sortAndFilterMatchingRange(Iterable<?> source, SpelCriteria criteria, @Nullable Comparator sort,
+	private List<?> sortAndFilterMatchingRange(Iterable<?> source, @Nullable SpelCriteria criteria, @Nullable Comparator sort,
 			long offset, int rows) {
 
 		List<?> tmp = IterableConverter.toList(source);

--- a/src/main/java/org/springframework/data/keyvalue/core/SpelQueryEngine.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SpelQueryEngine.java
@@ -25,6 +25,7 @@ import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.lang.Nullable;
 
 /**
  * {@link QueryEngine} implementation specific for executing {@link SpelExpression} based {@link KeyValueQuery} against
@@ -52,7 +53,7 @@ class SpelQueryEngine extends QueryEngine<KeyValueAdapter, SpelCriteria, Compara
 	 */
 	@Override
 	public Collection<?> execute(SpelCriteria criteria, Comparator<?> sort, long offset, int rows, String keyspace) {
-		return sortAndFilterMatchingRange(getAdapter().getAllOf(keyspace), criteria, sort, offset, rows);
+		return sortAndFilterMatchingRange(getRequiredAdapter().getAllOf(keyspace), criteria, sort, offset, rows);
 	}
 
 	/*
@@ -61,12 +62,13 @@ class SpelQueryEngine extends QueryEngine<KeyValueAdapter, SpelCriteria, Compara
 	 */
 	@Override
 	public long count(SpelCriteria criteria, String keyspace) {
-		return filterMatchingRange(IterableConverter.toList(getAdapter().getAllOf(keyspace)), criteria, -1, -1).size();
+		return filterMatchingRange(IterableConverter.toList(getRequiredAdapter().getAllOf(keyspace)), criteria, -1, -1)
+				.size();
 	}
 
 	@SuppressWarnings("unchecked")
-	private List<?> sortAndFilterMatchingRange(Iterable<?> source, SpelCriteria criteria, Comparator sort, long offset,
-			int rows) {
+	private List<?> sortAndFilterMatchingRange(Iterable<?> source, SpelCriteria criteria, @Nullable Comparator sort,
+			long offset, int rows) {
 
 		List<?> tmp = IterableConverter.toList(source);
 		if (sort != null) {
@@ -76,7 +78,8 @@ class SpelQueryEngine extends QueryEngine<KeyValueAdapter, SpelCriteria, Compara
 		return filterMatchingRange(tmp, criteria, offset, rows);
 	}
 
-	private static <S> List<S> filterMatchingRange(List<S> source, SpelCriteria criteria, long offset, int rows) {
+	private static <S> List<S> filterMatchingRange(List<S> source, @Nullable SpelCriteria criteria, long offset,
+			int rows) {
 
 		Stream<S> stream = source.stream();
 
@@ -93,6 +96,7 @@ class SpelQueryEngine extends QueryEngine<KeyValueAdapter, SpelCriteria, Compara
 		return stream.collect(Collectors.toList());
 	}
 
+	@SuppressWarnings("ConstantConditions")
 	private static boolean evaluateExpression(SpelCriteria criteria, Object candidate) {
 
 		try {

--- a/src/main/java/org/springframework/data/keyvalue/core/SpelSortAccessor.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/SpelSortAccessor.java
@@ -53,7 +53,7 @@ class SpelSortAccessor implements SortAccessor<Comparator<?>> {
 	@Override
 	public Comparator<?> resolve(KeyValueQuery<?> query) {
 
-		if (query == null || query.getSort() == null || query.getSort().isUnsorted()) {
+		if (query.getSort().isUnsorted()) {
 			return null;
 		}
 

--- a/src/main/java/org/springframework/data/keyvalue/core/UncategorizedKeyValueException.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/UncategorizedKeyValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,22 @@ package org.springframework.data.keyvalue.core;
 import org.springframework.dao.UncategorizedDataAccessException;
 
 /**
+ * Normal superclass when we can't distinguish anything more specific than "something went wrong with the underlying
+ * resource".
+ * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class UncategorizedKeyValueException extends UncategorizedDataAccessException {
 
 	private static final long serialVersionUID = -8087116071859122297L;
 
+	/**
+	 * Creates a new {@link UncategorizedKeyValueException}.
+	 * 
+	 * @param msg the detail message.
+	 * @param cause the root cause (usually from using a underlying data access API).
+	 */
 	public UncategorizedKeyValueException(String msg, Throwable cause) {
 		super(msg, cause);
 	}

--- a/src/main/java/org/springframework/data/keyvalue/core/UncategorizedKeyValueException.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/UncategorizedKeyValueException.java
@@ -20,7 +20,7 @@ import org.springframework.dao.UncategorizedDataAccessException;
 /**
  * Normal superclass when we can't distinguish anything more specific than "something went wrong with the underlying
  * resource".
- * 
+ *
  * @author Christoph Strobl
  * @author Mark Paluch
  */
@@ -30,7 +30,7 @@ public class UncategorizedKeyValueException extends UncategorizedDataAccessExcep
 
 	/**
 	 * Creates a new {@link UncategorizedKeyValueException}.
-	 * 
+	 *
 	 * @param msg the detail message.
 	 * @param cause the root cause (usually from using a underlying data access API).
 	 */

--- a/src/main/java/org/springframework/data/keyvalue/core/event/KeyValueEvent.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/event/KeyValueEvent.java
@@ -16,6 +16,7 @@
 package org.springframework.data.keyvalue.core.event;
 
 import org.springframework.context.ApplicationEvent;
+import org.springframework.lang.Nullable;
 
 /**
  * {@link KeyValueEvent} gets published for operations executed by eg.
@@ -24,6 +25,7 @@ import org.springframework.context.ApplicationEvent;
  *
  * @author Christoph Strobl
  * @author Thomas Darimont
+ * @author Mark Paluch
  * @param <T>
  */
 public class KeyValueEvent<T> extends ApplicationEvent {
@@ -71,7 +73,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 * @param value
 	 * @return
 	 */
-	public static <T> AfterGetEvent<T> afterGet(Object id, String keyspace, Class<T> type, T value) {
+	public static <T> AfterGetEvent<T> afterGet(Object id, String keyspace, Class<T> type, @Nullable T value) {
 		return new AfterGetEvent<>(id, keyspace, type, value);
 	}
 
@@ -125,7 +127,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 * @return
 	 */
 	public static <T> AfterUpdateEvent<T> afterUpdate(Object id, String keyspace, Class<? extends T> type, T actualValue,
-			Object previousValue) {
+			@Nullable Object previousValue) {
 		return new AfterUpdateEvent<>(id, keyspace, type, actualValue, previousValue);
 	}
 
@@ -172,7 +174,8 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	 * @param value
 	 * @return
 	 */
-	public static <T> AfterDeleteEvent<T> afterDelete(Object id, String keyspace, Class<? extends T> type, T value) {
+	public static <T> AfterDeleteEvent<T> afterDelete(Object id, String keyspace, Class<? extends T> type,
+			@Nullable T value) {
 		return new AfterDeleteEvent<>(id, keyspace, type, value);
 	}
 
@@ -223,9 +226,9 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	@SuppressWarnings("serial")
 	abstract static class KeyBasedEventWithPayload<T> extends KeyBasedEvent<T> {
 
-		private final T payload;
+		private final @Nullable T payload;
 
-		KeyBasedEventWithPayload(Object key, String keyspace, Class<? extends T> type, T payload) {
+		KeyBasedEventWithPayload(Object key, String keyspace, Class<? extends T> type, @Nullable T payload) {
 			super(key, keyspace, type);
 			this.payload = payload;
 		}
@@ -235,6 +238,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 		 *
 		 * @return
 		 */
+		@Nullable
 		public T getPayload() {
 			return payload;
 		}
@@ -264,7 +268,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	@SuppressWarnings("serial")
 	public static class AfterGetEvent<T> extends KeyBasedEventWithPayload<T> {
 
-		protected AfterGetEvent(Object key, String keyspace, Class<T> type, T payload) {
+		protected AfterGetEvent(Object key, String keyspace, Class<T> type, @Nullable T payload) {
 			super(key, keyspace, type, payload);
 		}
 
@@ -279,7 +283,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	@SuppressWarnings("serial")
 	public static class BeforeInsertEvent<T> extends KeyBasedEventWithPayload<T> {
 
-		public BeforeInsertEvent(Object key, String keyspace, Class<? extends T> type, T payload) {
+		public BeforeInsertEvent(Object key, String keyspace, Class<? extends T> type, @Nullable T payload) {
 			super(key, keyspace, type, payload);
 
 		}
@@ -294,7 +298,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	@SuppressWarnings("serial")
 	public static class AfterInsertEvent<T> extends KeyBasedEventWithPayload<T> {
 
-		public AfterInsertEvent(Object key, String keyspace, Class<? extends T> type, T payload) {
+		public AfterInsertEvent(Object key, String keyspace, Class<? extends T> type, @Nullable T payload) {
 			super(key, keyspace, type, payload);
 		}
 	}
@@ -308,7 +312,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	@SuppressWarnings("serial")
 	public static class BeforeUpdateEvent<T> extends KeyBasedEventWithPayload<T> {
 
-		public BeforeUpdateEvent(Object key, String keyspace, Class<? extends T> type, T payload) {
+		public BeforeUpdateEvent(Object key, String keyspace, Class<? extends T> type, @Nullable T payload) {
 			super(key, keyspace, type, payload);
 		}
 	}
@@ -322,9 +326,10 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	@SuppressWarnings("serial")
 	public static class AfterUpdateEvent<T> extends KeyBasedEventWithPayload<T> {
 
-		private final Object existing;
+		private final @Nullable Object existing;
 
-		public AfterUpdateEvent(Object key, String keyspace, Class<? extends T> type, T payload, Object existing) {
+		public AfterUpdateEvent(Object key, String keyspace, Class<? extends T> type, T payload,
+				@Nullable Object existing) {
 			super(key, keyspace, type, payload);
 			this.existing = existing;
 		}
@@ -334,6 +339,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 		 *
 		 * @return
 		 */
+		@Nullable
 		public Object before() {
 			return existing;
 		}
@@ -371,7 +377,7 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 	@SuppressWarnings("serial")
 	public static class AfterDeleteEvent<T> extends KeyBasedEventWithPayload<T> {
 
-		public AfterDeleteEvent(Object key, String keyspace, Class<? extends T> type, T payload) {
+		public AfterDeleteEvent(Object key, String keyspace, Class<? extends T> type, @Nullable T payload) {
 			super(key, keyspace, type, payload);
 		}
 	}

--- a/src/main/java/org/springframework/data/keyvalue/core/event/KeyValueEvent.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/event/KeyValueEvent.java
@@ -347,8 +347,9 @@ public class KeyValueEvent<T> extends ApplicationEvent {
 		/**
 		 * Get the current value.
 		 *
-		 * @return
+		 * @return can be {@literal null}.
 		 */
+		@Nullable
 		public T after() {
 			return getPayload();
 		}

--- a/src/main/java/org/springframework/data/keyvalue/core/event/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/event/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Support classes for key-value events, like standard persistence lifecycle events.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.core.event;

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/AnnotationBasedKeySpaceResolver.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/AnnotationBasedKeySpaceResolver.java
@@ -19,6 +19,7 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.annotation.Persistent;
 import org.springframework.data.keyvalue.annotation.KeySpace;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -28,6 +29,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 
@@ -38,6 +40,7 @@ enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 	 * @see org.springframework.data.keyvalue.core.KeySpaceResolver#resolveKeySpace(java.lang.Class)
 	 */
 	@Override
+	@Nullable
 	public String resolveKeySpace(Class<?> type) {
 
 		Assert.notNull(type, "Type for keyspace for null!");
@@ -48,6 +51,7 @@ enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 		return keySpace != null ? keySpace.toString() : null;
 	}
 
+	@Nullable
 	private static Object getKeySpace(Class<?> type) {
 
 		KeySpace keyspace = AnnotatedElementUtils.findMergedAnnotation(type, KeySpace.class);

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/BasicKeyValuePersistentEntity.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/BasicKeyValuePersistentEntity.java
@@ -17,6 +17,7 @@ package org.springframework.data.keyvalue.core.mapping;
 
 import org.springframework.data.mapping.model.BasicPersistentEntity;
 import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -24,6 +25,7 @@ import org.springframework.util.StringUtils;
  * 
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Mark Paluch
  * @param <T>
  */
 public class BasicKeyValuePersistentEntity<T, P extends KeyValuePersistentProperty<P>>
@@ -37,14 +39,15 @@ public class BasicKeyValuePersistentEntity<T, P extends KeyValuePersistentProper
 	 * @param information must not be {@literal null}.
 	 * @param keySpaceResolver can be {@literal null}.
 	 */
-	public BasicKeyValuePersistentEntity(TypeInformation<T> information, KeySpaceResolver fallbackKeySpaceResolver) {
+	public BasicKeyValuePersistentEntity(TypeInformation<T> information,
+			@Nullable KeySpaceResolver fallbackKeySpaceResolver) {
 
 		super(information);
 
 		this.keyspace = detectKeySpace(information.getType(), fallbackKeySpaceResolver);
 	}
 
-	private static String detectKeySpace(Class<?> type, KeySpaceResolver fallback) {
+	private static String detectKeySpace(Class<?> type, @Nullable KeySpaceResolver fallback) {
 
 		String keySpace = AnnotationBasedKeySpaceResolver.INSTANCE.resolveKeySpace(type);
 

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/BasicKeyValuePersistentEntity.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/BasicKeyValuePersistentEntity.java
@@ -33,7 +33,7 @@ public class BasicKeyValuePersistentEntity<T, P extends KeyValuePersistentProper
 
 	private static final KeySpaceResolver DEFAULT_FALLBACK_RESOLVER = ClassNameKeySpaceResolver.INSTANCE;
 
-	private final String keyspace;
+	private final @Nullable String keyspace;
 
 	/**
 	 * @param information must not be {@literal null}.
@@ -47,6 +47,7 @@ public class BasicKeyValuePersistentEntity<T, P extends KeyValuePersistentProper
 		this.keyspace = detectKeySpace(information.getType(), fallbackKeySpaceResolver);
 	}
 
+	@Nullable
 	private static String detectKeySpace(Class<?> type, @Nullable KeySpaceResolver fallback) {
 
 		String keySpace = AnnotationBasedKeySpaceResolver.INSTANCE.resolveKeySpace(type);

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/KeySpaceResolver.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/KeySpaceResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 package org.springframework.data.keyvalue.core.mapping;
 
+import org.springframework.lang.Nullable;
+
 /**
  * {@link KeySpaceResolver} determines the {@literal keyspace} a given type is assigned to. A keyspace in this context
  * is a specific region/collection/grouping of elements sharing a common keyrange. <br />
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface KeySpaceResolver {
 
@@ -29,5 +32,6 @@ public interface KeySpaceResolver {
 	 * @param type must not be {@literal null}.
 	 * @return
 	 */
+	@Nullable
 	String resolveKeySpace(Class<?> type);
 }

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/KeyValuePersistentEntity.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/KeyValuePersistentEntity.java
@@ -16,6 +16,7 @@
 package org.springframework.data.keyvalue.core.mapping;
 
 import org.springframework.data.mapping.model.MutablePersistentEntity;
+import org.springframework.lang.Nullable;
 
 /**
  * @author Christoph Strobl
@@ -27,7 +28,8 @@ public interface KeyValuePersistentEntity<T, P extends KeyValuePersistentPropert
 	/**
 	 * Get the {@literal keySpace} a given entity assigns to.
 	 * 
-	 * @return never {@literal null}.
+	 * @return can be {@literal null}.
 	 */
+	@Nullable
 	String getKeySpace();
 }

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/context/KeyValueMappingContext.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/context/KeyValueMappingContext.java
@@ -24,6 +24,7 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
 
 /**
  * Default implementation of a {@link MappingContext} using {@link KeyValuePersistentEntity} and
@@ -36,7 +37,7 @@ import org.springframework.data.util.TypeInformation;
 public class KeyValueMappingContext<E extends KeyValuePersistentEntity<?, P>, P extends KeyValuePersistentProperty<P>>
 		extends AbstractMappingContext<E, P> {
 
-	private KeySpaceResolver fallbackKeySpaceResolver;
+	private @Nullable KeySpaceResolver fallbackKeySpaceResolver;
 
 	/**
 	 * Configures the {@link KeySpaceResolver} to be used if not explicit key space is annotated to the domain type.

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/context/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/context/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Infrastructure for the Key-Value mapping context.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.core.mapping.context;

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Infrastructure for the Key-Value mapping subsystem and keyspace resolution.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.core.mapping;

--- a/src/main/java/org/springframework/data/keyvalue/core/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Core key/value implementation.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.core;

--- a/src/main/java/org/springframework/data/keyvalue/core/query/KeyValueQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/query/KeyValueQuery.java
@@ -16,6 +16,8 @@
 package org.springframework.data.keyvalue.core.query;
 
 import org.springframework.data.domain.Sort;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
@@ -27,7 +29,7 @@ public class KeyValueQuery<T> {
 	private Sort sort = Sort.unsorted();
 	private long offset = -1;
 	private int rows = -1;
-	private T criteria;
+	private @Nullable T criteria;
 
 	/**
 	 * Creates new instance of {@link KeyValueQuery}.
@@ -39,17 +41,17 @@ public class KeyValueQuery<T> {
 	 *
 	 * @param criteria can be {@literal null}.
 	 */
-	public KeyValueQuery(T criteria) {
+	public KeyValueQuery(@Nullable T criteria) {
 		this.criteria = criteria;
 	}
 
 	/**
 	 * Creates new instance of {@link KeyValueQuery} with given {@link Sort}.
 	 *
-	 * @param sort can be {@literal null}.
+	 * @param sort must not be {@literal null}.
 	 */
 	public KeyValueQuery(Sort sort) {
-		this.sort = sort;
+		setSort(sort);
 	}
 
 	/**
@@ -58,6 +60,7 @@ public class KeyValueQuery<T> {
 	 * @return
 	 * @since 2.0
 	 */
+	@Nullable
 	public T getCriteria() {
 		return criteria;
 	}
@@ -113,26 +116,28 @@ public class KeyValueQuery<T> {
 	 * @param sort
 	 */
 	public void setSort(Sort sort) {
+
+		Assert.notNull(sort, "Sort must not be null!");
+
 		this.sort = sort;
 	}
 
 	/**
 	 * Add given {@link Sort}.
 	 *
-	 * @param sort {@literal null} {@link Sort} will be ignored.
+	 * @param sort must not be {@literal null}.
 	 * @return
 	 */
 	public KeyValueQuery<T> orderBy(Sort sort) {
 
-		if (sort == null) {
-			return this;
-		}
+		Assert.notNull(sort, "Sort must not be null!");
 
-		if (this.sort != null) {
+		if (this.sort.isSorted()) {
 			this.sort = this.sort.and(sort);
 		} else {
 			this.sort = sort;
 		}
+
 		return this;
 	}
 
@@ -142,7 +147,9 @@ public class KeyValueQuery<T> {
 	 * @return
 	 */
 	public KeyValueQuery<T> skip(long offset) {
+
 		setOffset(offset);
+
 		return this;
 	}
 

--- a/src/main/java/org/springframework/data/keyvalue/core/query/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/query/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Key/value specific query and abstractions.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.core.query;

--- a/src/main/java/org/springframework/data/keyvalue/repository/config/KeyValueRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/config/KeyValueRepositoryConfigurationExtension.java
@@ -35,6 +35,7 @@ import org.springframework.data.repository.config.AnnotationRepositoryConfigurat
 import org.springframework.data.repository.config.RepositoryConfigurationExtension;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
+import org.springframework.lang.Nullable;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -42,6 +43,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public abstract class KeyValueRepositoryConfigurationExtension extends RepositoryConfigurationExtensionSupport {
 
@@ -177,6 +179,7 @@ public abstract class KeyValueRepositoryConfigurationExtension extends Repositor
 	 *
 	 * @return {@literal null} to explicitly not register a template.
 	 */
+	@Nullable
 	protected AbstractBeanDefinition getDefaultKeyValueTemplateBeanDefinition(
 			RepositoryConfigurationSource configurationSource) {
 		return null;

--- a/src/main/java/org/springframework/data/keyvalue/repository/config/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/config/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Support infrastructure for the configuration of key/value specific repositories.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.repository.config;

--- a/src/main/java/org/springframework/data/keyvalue/repository/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Key/value specific repository implementation.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.repository;

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/CachingKeyValuePartTreeQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/CachingKeyValuePartTreeQuery.java
@@ -21,17 +21,19 @@ import org.springframework.data.repository.query.EvaluationContextProvider;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.data.repository.query.parser.PartTree;
+import org.springframework.lang.Nullable;
 
 /**
  * {@link KeyValuePartTreeQuery} implementation deriving queries from {@link PartTree} using a predefined
  * {@link AbstractQueryCreator} that caches the once created query.
  * 
  * @author Christoph Strobl
+ * @author Mark Paluch
  * @since 1.1
  */
 public class CachingKeyValuePartTreeQuery extends KeyValuePartTreeQuery {
 
-	private KeyValueQuery<?> cachedQuery;
+	private @Nullable KeyValueQuery<?> cachedQuery;
 
 	public CachingKeyValuePartTreeQuery(QueryMethod queryMethod, EvaluationContextProvider evaluationContextProvider,
 			KeyValueOperations keyValueOperations, Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/KeyValuePartTreeQuery.java
@@ -35,6 +35,7 @@ import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -94,6 +95,7 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 	 * @param parameters
 	 * @param query
 	 */
+	@Nullable
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	protected Object doExecute(Object[] parameters, KeyValueQuery<?> query) {
 
@@ -179,8 +181,12 @@ public class KeyValuePartTreeQuery implements RepositoryQuery {
 
 		PartTree tree = new PartTree(getQueryMethod().getName(), getQueryMethod().getEntityInformation().getJavaType());
 
-		Constructor<? extends AbstractQueryCreator<?, ?>> constructor = ClassUtils
-				.getConstructorIfAvailable(queryCreator, PartTree.class, ParameterAccessor.class);
+		Constructor<? extends AbstractQueryCreator<?, ?>> constructor = ClassUtils.getConstructorIfAvailable(queryCreator,
+				PartTree.class, ParameterAccessor.class);
+
+		Assert.state(constructor != null, String.format("Constructor %s(PartTree, ParameterAccessor) not available!",
+				ClassUtils.getShortName(queryCreator)));
+
 		KeyValueQuery<?> query = (KeyValueQuery<?>) BeanUtils.instantiateClass(constructor, tree, accessor).createQuery();
 
 		if (tree.isLimiting()) {

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/SpelQueryCreator.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/SpelQueryCreator.java
@@ -89,7 +89,7 @@ public class SpelQueryCreator extends AbstractQueryCreator<KeyValueQuery<SpelExp
 
 		KeyValueQuery<SpelExpression> query = new KeyValueQuery<>(this.expression);
 
-		if (sort != null) {
+		if (sort.isSorted()) {
 			query.orderBy(sort);
 		}
 

--- a/src/main/java/org/springframework/data/keyvalue/repository/query/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/query/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Query derivation mechanism for key/value specific repositories providing a generic SpEL based implementation.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.repository.query;

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueQuerydslUtils.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueQuerydslUtils.java
@@ -37,6 +37,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 abstract class KeyValueQuerydslUtils {
 
@@ -47,17 +48,14 @@ abstract class KeyValueQuerydslUtils {
 	/**
 	 * Transforms a plain {@link Order} into a QueryDsl specific {@link OrderSpecifier}.
 	 *
-	 * @param sort
+	 * @param sort must not be {@literal null}.
 	 * @param builder must not be {@literal null}.
 	 * @return empty {@code OrderSpecifier<?>[]} when sort is {@literal null}.
 	 */
 	static OrderSpecifier<?>[] toOrderSpecifier(Sort sort, PathBuilder<?> builder) {
 
-		Assert.notNull(builder, "Builder must not be 'null'.");
-
-		if (sort == null) {
-			return new OrderSpecifier<?>[0];
-		}
+		Assert.notNull(sort, "Sort must not be null.");
+		Assert.notNull(builder, "Builder must not be null.");
 
 		List<OrderSpecifier<?>> specifiers = null;
 

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactory.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.keyvalue.repository.support;
 
-import static org.springframework.data.querydsl.QuerydslUtils.QUERY_DSL_PRESENT;
+import static org.springframework.data.querydsl.QuerydslUtils.*;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -41,6 +41,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy.Key;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -75,7 +76,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 	 * {@link AbstractQueryCreator}-type.
 	 *
 	 * @param keyValueOperations must not be {@literal null}.
-	 * @param queryCreator defaulted to {@link #DEFAULT_QUERY_CREATOR} if {@literal null}.
+	 * @param queryCreator must not be {@literal null}.
 	 */
 	public KeyValueRepositoryFactory(KeyValueOperations keyValueOperations,
 			Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
@@ -154,9 +155,10 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 	 * @see org.springframework.data.repository.core.support.RepositoryFactorySupport#getQueryLookupStrategy(org.springframework.data.repository.query.QueryLookupStrategy.Key, org.springframework.data.repository.query.EvaluationContextProvider)
 	 */
 	@Override
-	protected Optional<QueryLookupStrategy> getQueryLookupStrategy(Key key, EvaluationContextProvider evaluationContextProvider) {
-		return Optional.of(new KeyValueQueryLookupStrategy(key, evaluationContextProvider, this.keyValueOperations, this.queryCreator,
-				this.repositoryQueryType));
+	protected Optional<QueryLookupStrategy> getQueryLookupStrategy(@Nullable Key key,
+			EvaluationContextProvider evaluationContextProvider) {
+		return Optional.of(new KeyValueQueryLookupStrategy(key, evaluationContextProvider, this.keyValueOperations,
+				this.queryCreator, this.repositoryQueryType));
 	}
 
 	/**
@@ -194,7 +196,7 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 		 * @param queryCreator
 		 * @since 1.1
 		 */
-		public KeyValueQueryLookupStrategy(Key key, EvaluationContextProvider evaluationContextProvider,
+		public KeyValueQueryLookupStrategy(@Nullable Key key, EvaluationContextProvider evaluationContextProvider,
 				KeyValueOperations keyValueOperations, Class<? extends AbstractQueryCreator<?, ?>> queryCreator,
 				Class<? extends RepositoryQuery> repositoryQueryType) {
 
@@ -223,6 +225,11 @@ public class KeyValueRepositoryFactory extends RepositoryFactorySupport {
 			Constructor<? extends KeyValuePartTreeQuery> constructor = (Constructor<? extends KeyValuePartTreeQuery>) ClassUtils
 					.getConstructorIfAvailable(this.repositoryQueryType, QueryMethod.class, EvaluationContextProvider.class,
 							KeyValueOperations.class, Class.class);
+
+			Assert.state(constructor != null,
+					String.format(
+							"Constructor %s(QueryMethod, EvaluationContextProvider, KeyValueOperations, Class) not available!",
+							ClassUtils.getShortName(this.repositoryQueryType)));
 
 			return BeanUtils.instantiateClass(constructor, queryMethod, evaluationContextProvider, this.keyValueOperations,
 					this.queryCreator);

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/KeyValueRepositoryFactoryBean.java
@@ -24,6 +24,7 @@ import org.springframework.data.repository.core.support.RepositoryFactoryBeanSup
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -36,9 +37,9 @@ import org.springframework.util.Assert;
 public class KeyValueRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
 		extends RepositoryFactoryBeanSupport<T, S, ID> {
 
-	private KeyValueOperations operations;
-	private Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
-	private Class<? extends RepositoryQuery> repositoryQueryType;
+	private @Nullable KeyValueOperations operations;
+	private @Nullable Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
+	private @Nullable Class<? extends RepositoryQuery> repositoryQueryType;
 
 	/**
 	 * Creates a new {@link KeyValueRepositoryFactoryBean} for the given repository interface.

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/package-info.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Support infrastructure for query derivation of key/value specific repositories.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.keyvalue.repository.support;

--- a/src/main/java/org/springframework/data/map/package-info.java
+++ b/src/main/java/org/springframework/data/map/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Repository implementation backed by generic {@link java.util.Map} instances.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.map;

--- a/src/main/java/org/springframework/data/map/repository/config/package-info.java
+++ b/src/main/java/org/springframework/data/map/repository/config/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Support infrastructure for the configuration of {@link java.util.Map} repositories.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.map.repository.config;

--- a/src/test/java/org/springframework/data/keyvalue/core/IterableConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/IterableConverterUnitTests.java
@@ -30,13 +30,9 @@ import org.junit.Test;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class IterableConverterUnitTests {
-
-	@Test // DATAKV-101
-	public void toListShouldReturnEmptyListWhenSourceIsNull() {
-		assertThat(toList(null), notNullValue());
-	}
 
 	@Test // DATAKV-101
 	public void toListShouldReturnEmptyListWhenSourceEmpty() {

--- a/src/test/java/org/springframework/data/keyvalue/repository/support/KeyValueQuerydslUtilsUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/repository/support/KeyValueQuerydslUtilsUnitTests.java
@@ -39,6 +39,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
  * @author Christoph Strobl
  * @author Thomas Darimont
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class KeyValueQuerydslUtilsUnitTests {
 
@@ -57,9 +58,9 @@ public class KeyValueQuerydslUtilsUnitTests {
 		toOrderSpecifier(Sort.by("firstname"), null);
 	}
 
-	@Test // DATACMNS-525
-	public void toOrderSpecifierReturnsEmptyArrayWhenSortIsNull() {
-		assertThat(toOrderSpecifier(null, builder), arrayWithSize(0));
+	@Test // DATACMNS-525, DATAKV-197
+	public void toOrderSpecifierReturnsEmptyArrayWhenSortIsUnsorted() {
+		assertThat(toOrderSpecifier(Sort.unsorted(), builder), arrayWithSize(0));
 	}
 
 	@Test // DATACMNS-525

--- a/src/test/java/org/springframework/data/map/QuerydslKeyValueRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/map/QuerydslKeyValueRepositoryUnitTests.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Lists;
  * @author Christoph Strobl
  * @author Oliver Gierke
  * @author Thomas Darimont
+ * @author Mark Paluch
  */
 public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitTests<QPersonRepository> {
 
@@ -76,8 +77,7 @@ public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitT
 		assertThat(page1.getContent(), hasSize(1));
 		assertThat(page1.hasNext(), is(true));
 
-		Page<Person> page2 = repository.findAll(QPerson.person.age.eq(CERSEI.getAge()),
-				page1.nextPageable());
+		Page<Person> page2 = repository.findAll(QPerson.person.age.eq(CERSEI.getAge()), page1.nextPageable());
 
 		assertThat(page2.getTotalElements(), is(2L));
 		assertThat(page2.getContent(), hasSize(1));
@@ -127,12 +127,17 @@ public class QuerydslKeyValueRepositoryUnitTests extends AbstractRepositoryUnitT
 		assertThat(result, contains(TYRION, JAIME, CERSEI));
 	}
 
-	@Test // DATAKV-90
-	public void findAllShouldIgnoreNullOrderSpecifier() {
+	@Test(expected = IllegalArgumentException.class) // DATAKV-90, DATAKV-197
+	public void findAllShouldRequireSort() {
+		repository.findAll((QSort) null);
+	}
+
+	@Test // DATAKV-90, DATAKV-197
+	public void findAllShouldAllowUnsortedFindAll() {
 
 		repository.saveAll(LENNISTERS);
 
-		Iterable<Person> result = repository.findAll((QSort) null);
+		Iterable<Person> result = repository.findAll(Sort.unsorted());
 
 		assertThat(result, containsInAnyOrder(TYRION, JAIME, CERSEI));
 	}


### PR DESCRIPTION
Annotate all packages with Spring Frameworks `@NonNullApi` and `@NonNullFields`. Add Spring's `@Nullable` to methods, parameters, and fields that take or produce `null` values. Adapted using code to make sure the IDE can evaluate the null flow properly. 

Fix Javadoc in places where an invalid `null` handling policy was advertised. Strengthened `null` requirements for types that expose `null`-instances.

---

Related ticket: [DATAKV-197](https://jira.spring.io/browse/DATAKV-197).