### PR TITLE
DATAKV-206 - Support for custom identifier generators.

### DIFF
--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
@@ -46,6 +46,7 @@ import org.springframework.util.CollectionUtils;
  * @author Oliver Gierke
  * @author Thomas Darimont
  * @author Mark Paluch
+ * @author Mert Zeybekler
  */
 public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPublisherAware {
 
@@ -86,6 +87,26 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 		this.adapter = adapter;
 		this.mappingContext = mappingContext;
 		this.identifierGenerator = DefaultIdentifierGenerator.INSTANCE;
+	}
+
+	/**
+	 * Create new {@link KeyValueTemplate} using the given {@link KeyValueAdapter} and {@link MappingContext}.
+	 *
+	 * @param adapter must not be {@literal null}.
+	 * @param mappingContext must not be {@literal null}.
+	 * @param identifierGenerator must not be {@literal null}.
+	 */
+	public KeyValueTemplate(KeyValueAdapter adapter,
+			MappingContext<? extends KeyValuePersistentEntity<?, ?>, ? extends KeyValuePersistentProperty<?>> mappingContext,
+			IdentifierGenerator identifierGenerator) {
+
+		Assert.notNull(adapter, "Adapter must not be null!");
+		Assert.notNull(mappingContext, "MappingContext must not be null!");
+		Assert.notNull(identifierGenerator, "IdentifierGenerator must not be null!");
+
+		this.adapter = adapter;
+		this.mappingContext = mappingContext;
+		this.identifierGenerator = identifierGenerator;
 	}
 
 	/**


### PR DESCRIPTION
`KeyValueTemplate` now exposes an additional constructor which includes `identifierGenerator` as a parameter which allows to assign a custom implementation of `IdentifierGenerator`.