### PR TITLE
DATAKV-225 - Add support for immutable objects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATAKV-225-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 
@@ -17,7 +17,7 @@
 	</parent>
 
 	<properties>
-		<springdata.commons>2.1.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>2.1.0.DATACMNS-1322-SNAPSHOT</springdata.commons>
 		<java-module-name>spring.data.keyvalue</java-module-name>
 	</properties>
 

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueOperations.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueOperations.java
@@ -36,7 +36,7 @@ public interface KeyValueOperations extends DisposableBean {
 	 * Add given object. Object needs to have id property to which a generated value will be assigned.
 	 *
 	 * @param objectToInsert
-	 * @return
+	 * @return the inserted object.
 	 */
 	<T> T insert(T objectToInsert);
 
@@ -45,8 +45,9 @@ public interface KeyValueOperations extends DisposableBean {
 	 *
 	 * @param id must not be {@literal null}.
 	 * @param objectToInsert must not be {@literal null}.
+	 * @return the inserted object.
 	 */
-	void insert(Object id, Object objectToInsert);
+	<T> T insert(Object id, T objectToInsert);
 
 	/**
 	 * Get all elements of given type. Respects {@link KeySpace} if present and therefore returns all elements that can be
@@ -121,14 +122,16 @@ public interface KeyValueOperations extends DisposableBean {
 
 	/**
 	 * @param objectToUpdate must not be {@literal null}.
+	 * @return the updated object.
 	 */
-	void update(Object objectToUpdate);
+	<T> T update(T objectToUpdate);
 
 	/**
 	 * @param id must not be {@literal null}.
 	 * @param objectToUpdate must not be {@literal null}.
+	 * @return the updated object.
 	 */
-	void update(Object id, Object objectToUpdate);
+	<T> T update(Object id, T objectToUpdate);
 
 	/**
 	 * Remove all elements of type. Respects {@link KeySpace} if present and therefore removes all elements that can be

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
@@ -137,8 +137,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 				entity.getIdProperty(), identifierGenerator);
 		Object id = generatingIdAccessor.getOrGenerateIdentifier();
 
-		insert(id, objectToInsert);
-		return objectToInsert;
+		return insert(id, objectToInsert);
 	}
 
 	/*
@@ -146,7 +145,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 	 * @see org.springframework.data.keyvalue.core.KeyValueOperations#insert(java.lang.Object, java.lang.Object)
 	 */
 	@Override
-	public void insert(Object id, Object objectToInsert) {
+	public <T> T insert(Object id, T objectToInsert) {
 
 		Assert.notNull(id, "Id for object to be inserted must not be null!");
 		Assert.notNull(objectToInsert, "Object to be inserted must not be null!");
@@ -167,6 +166,8 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 		});
 
 		potentiallyPublishEvent(KeyValueEvent.afterInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
+
+		return objectToInsert;
 	}
 
 	/*
@@ -175,7 +176,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 	 */
 	@SuppressWarnings("rawtypes")
 	@Override
-	public void update(Object objectToUpdate) {
+	public <T> T update(T objectToUpdate) {
 
 		KeyValuePersistentEntity<?, ?> entity = getKeyValuePersistentEntity(objectToUpdate);
 
@@ -184,7 +185,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 					String.format("Cannot determine id for type %s", ClassUtils.getUserClass(objectToUpdate)));
 		}
 
-		update(entity.getIdentifierAccessor(objectToUpdate).getRequiredIdentifier(), objectToUpdate);
+		return update(entity.getIdentifierAccessor(objectToUpdate).getRequiredIdentifier(), objectToUpdate);
 	}
 
 	/*
@@ -192,7 +193,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 	 * @see org.springframework.data.keyvalue.core.KeyValueOperations#update(java.lang.Object, java.lang.Object)
 	 */
 	@Override
-	public void update(Object id, Object objectToUpdate) {
+	public <T> T update(Object id, T objectToUpdate) {
 
 		Assert.notNull(id, "Id for object to be inserted must not be null!");
 		Assert.notNull(objectToUpdate, "Object to be updated must not be null!");
@@ -205,6 +206,8 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 
 		potentiallyPublishEvent(
 				KeyValueEvent.afterUpdate(id, keyspace, objectToUpdate.getClass(), objectToUpdate, existing));
+
+		return objectToUpdate;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/SimpleKeyValueRepository.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/SimpleKeyValueRepository.java
@@ -98,11 +98,10 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 		Assert.notNull(entity, "Entity must not be null!");
 
 		if (entityInformation.isNew(entity)) {
-			operations.insert(entity);
-		} else {
-			operations.update(entityInformation.getRequiredId(entity), entity);
+			return operations.insert(entity);
 		}
-		return entity;
+
+		return operations.update(entityInformation.getRequiredId(entity), entity);
 	}
 
 	/*
@@ -112,9 +111,13 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 	@Override
 	public <S extends T> Iterable<S> saveAll(Iterable<S> entities) {
 
-		entities.forEach(this::save);
+		List<S> saved = new ArrayList<>();
 
-		return entities;
+		for (S entity : entities) {
+			saved.add(save(entity));
+		}
+
+		return saved;
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
@@ -110,6 +110,15 @@ public class KeyValueTemplateUnitTests {
 		verify(adapterMock, times(1)).put("1", FOO_ONE, Foo.class.getName());
 	}
 
+	@Test // DATACMNS-225
+	public void insertShouldReturnInsertedObject() {
+
+		ClassWithStringId object = new ClassWithStringId();
+
+		assertThat(template.insert(object), is(object));
+		assertThat(template.insert("1", object), is(object));
+	}
+
 	@Test // DATACMNS-525
 	public void insertShouldThrowExceptionWhenObectWithIdAlreadyExists() {
 
@@ -223,6 +232,16 @@ public class KeyValueTemplateUnitTests {
 		template.update("1", FOO_TWO);
 
 		verify(adapterMock, times(1)).put("1", FOO_TWO, Foo.class.getName());
+	}
+
+	@Test // DATAKV-225
+	public void updateShouldReturnUpdatedObject() {
+
+		ClassWithStringId object = new ClassWithStringId();
+		object.id = "foo";
+
+		assertThat(template.update(object), is(object));
+		assertThat(template.update("1", object), is(object));
 	}
 
 	@Test(expected = IllegalArgumentException.class) // DATACMNS-525


### PR DESCRIPTION
Add return types to `KeyValueOperations` methods to return potentially changed object instances. Return `KeyValueOperations.insert/update` method result in `SimpleKeyValueRepository.save(…)`.

---

Related ticket: [DATAKV-225](https://jira.spring.io/browse/DATAKV-225).
Required by: [DATAREDIS-849](https://jira.spring.io/browse/DATAREDIS-849).
Depends on: [DATACMNS-1322](https://jira.spring.io/browse/DATACMNS-1322), https://github.com/spring-projects/spring-data-commons/pull/292