### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 image:https://travis-ci.org/spring-projects/spring-data-keyvalue.svg?branch=master["Build Status", link="https://travis-ci.org/spring-projects/spring-data-keyvalue"]
 
-The primary goal of the http://projects.spring.io/spring-data[Spring Data] project is to make it easier to build Spring-powered applications that use data access technologies. This module provides infrastructure components to build repository abstractions for stores dealing with Key/Value pairs and ships with a default `java.util.Map` based implementation.
+The primary goal of the https://projects.spring.io/spring-data[Spring Data] project is to make it easier to build Spring-powered applications that use data access technologies. This module provides infrastructure components to build repository abstractions for stores dealing with Key/Value pairs and ships with a default `java.util.Map` based implementation.
 
 ## Features
 
@@ -31,7 +31,7 @@ For snapshot versions, make sure you include the spring snapshots repository:
 <repositories>
   <repository>
     <id>spring-libs-snapshot</id>
-    <url>http://repo.spring.io/libs-snapshot</url>
+    <url>https://repo.spring.io/libs-snapshot</url>
   </repository>
 </repositories>
 ----
@@ -86,10 +86,10 @@ To have the maximum performance we encourage you to use the latest Spring 4.1.x 
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community by helping out on http://stackoverflow.com/questions/tagged/spring-data-keyvalue[stackoverflow] by responding to questions and joining the debate.
+* Get involved with the Spring community by helping out on https://stackoverflow.com/questions/tagged/spring-data-keyvalue[stackoverflow] by responding to questions and joining the debate.
 * Create https://jira.spring.io/browse/DATAKV[JIRA] tickets for bugs and new features and comment and vote on the ones that you are interested in.
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from http://help.github.com/forking[forks of this repository]. If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by http://spring.io/blog[subscribing] to spring.io.
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from https://help.github.com/forking[forks of this repository]. If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by https://spring.io/blog[subscribing] to spring.io.
 
 Before we accept a non-trivial patch or pull request we will need you to https://cla.pivotal.io/sign/spring[sign the Contributor License Agreement]. Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request.
  Active contributors might be asked to join the core team, and given the ability to merge pull requests.

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -4,7 +4,7 @@ Oliver Gierke; Thomas Darimont; Christoph Strobl; Jay Bryant
 :revdate: {localdate}
 ifdef::backend-epub3[:front-cover-image: image:epub-cover.png[Front Cover,1050,1600]]
 :spring-data-commons-docs: https://raw.githubusercontent.com/spring-projects/spring-data-commons/master/src/main/asciidoc
-:spring-framework-docs: http://docs.spring.io/spring-framework/docs/{springVersion}/spring-framework-reference/
+:spring-framework-docs: https://docs.spring.io/spring-framework/docs/{springVersion}/spring-framework-reference/
 
 (C) 2008-2019 The original authors.
 

--- a/src/main/asciidoc/key-value-repositories.adoc
+++ b/src/main/asciidoc/key-value-repositories.adoc
@@ -1,4 +1,4 @@
-:spring-framework-docs: http://docs.spring.io/spring-framework/docs/{springVersion}/spring-framework-reference/
+:spring-framework-docs: https://docs.spring.io/spring-framework/docs/{springVersion}/spring-framework-reference/
 
 [[key-value]]
 = Key-Value Repositories

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -5,7 +5,7 @@
 [preface]
 == Project Metadata
 
-* Version control: http://github.com/spring-projects/spring-data-keyvalue
+* Version control: https://github.com/spring-projects/spring-data-keyvalue
 * Bugtracker: https://jira.spring.io/browse/DATAKV
 * Release repository: https://repo.spring.io/libs-release
 * Milestone repository: https://repo.spring.io/libs-milestone

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -244,13 +244,13 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
-Copyright (c) 1999-2009, OW2 Consortium <http://www.ow2.org/>
+Copyright (c) 1999-2009, OW2 Consortium <https://www.ow2.org/>
 
 
 >>> CGLIB 3.0 (cglib:cglib:3.0):
 
 Per the LICENSE file in the CGLIB JAR distribution downloaded from
-http://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download,
+https://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download,
 CGLIB 3.0 is licensed under the Apache License, version 2.0, the text of which
 is included above.
 
@@ -262,7 +262,7 @@ other similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a
 copy of the source code corresponding to the binaries for such open source
 components and modifications thereto, if any, (the "Source Files"), by
-downloading the Source Files from http://www.springsource.org/download, or by
+downloading the Source Files from https://www.springsource.org/download, or by
 sending a request, with your name and address to:
 
     VMware, Inc., 3401 Hillview Avenue


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://github.com/spring-projects/spring-data-keyvalue with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-data-keyvalue ([https](https://github.com/spring-projects/spring-data-keyvalue) result 200).
* [ ] http://spring.io/blog with 1 occurrences migrated to:  
  https://spring.io/blog ([https](https://spring.io/blog) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data-keyvalue with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data-keyvalue ([https](https://stackoverflow.com/questions/tagged/spring-data-keyvalue) result 200).
* [ ] http://www.ow2.org/ with 1 occurrences migrated to:  
  https://www.ow2.org/ ([https](https://www.ow2.org/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-framework/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/ ([https](https://docs.spring.io/spring-framework/docs/) result 301).
* [ ] http://help.github.com/forking with 1 occurrences migrated to:  
  https://help.github.com/forking ([https](https://help.github.com/forking) result 301).
* [ ] http://projects.spring.io/spring-data with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data ([https](https://projects.spring.io/spring-data) result 301).
* [ ] http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* [ ] http://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download with 1 occurrences migrated to:  
  https://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download ([https](https://sourceforge.net/projects/cglib/files/cglib3/3.0/cglib-3.0.jar/download) result 302).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).