### PR TITLE
DATAKV-268 - Add SpEL support for @KeySpace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>2.2.0.BUILD-SNAPSHOT</version>
+	<version>2.2.0.DATAKV-268-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/annotation/KeySpace.java
+++ b/src/main/java/org/springframework/data/keyvalue/annotation/KeySpace.java
@@ -26,7 +26,8 @@ import org.springframework.data.annotation.Persistent;
 
 /**
  * Marker interface for methods with {@link Persistent} annotations indicating the presence of a dedicated keyspace the
- * entity should reside in. If present the value will be picked up for resolving the keyspace.
+ * entity should reside in. If present the value will be picked up for resolving the keyspace. The {@link #value()}
+ * attribute supports SpEL expressions to dynamically resolve the keyspace based on a per-operation basis.
  *
  * <pre>
  * <code>

--- a/src/main/java/org/springframework/data/keyvalue/annotation/KeySpace.java
+++ b/src/main/java/org/springframework/data/keyvalue/annotation/KeySpace.java
@@ -29,33 +29,29 @@ import org.springframework.data.annotation.Persistent;
  * entity should reside in. If present the value will be picked up for resolving the keyspace. The {@link #value()}
  * attribute supports SpEL expressions to dynamically resolve the keyspace based on a per-operation basis.
  *
- * <pre>
- * <code>
+ * <pre class="code">
  * &#64;Persistent
  * &#64;Retention(RetentionPolicy.RUNTIME)
  * &#64;Target({ ElementType.TYPE })
  * static @interface CacheCentricAnnotation {
  *
- *   &#64;AliasFor(annotation = KeySpace.class, attribute = "value")
- *   String cacheRegion() default "";
+ * 	&#64;AliasFor(annotation = KeySpace.class, attribute = "value")
+ * 	String cacheRegion() default "";
  * }
  *
  * &#64;CacheCentricAnnotation(cacheRegion = "customers")
  * class Customer {
- *   //...
+ * 	// ...
  * }
- * </code>
  * </pre>
  *
  * Can also be directly used on types to indicate the keyspace.
  *
- * <pre>
- * <code>
+ * <pre class="code">
  * &#64;KeySpace("persons")
  * public class Foo {
  *
  * }
- * </code>
  * </pre>
  *
  * @author Christoph Strobl

--- a/src/test/java/org/springframework/data/keyvalue/core/mapping/BasicKeyValuePersistentEntityUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/mapping/BasicKeyValuePersistentEntityUnitTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.keyvalue.core.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.data.keyvalue.annotation.KeySpace;
+import org.springframework.data.keyvalue.core.mapping.context.KeyValueMappingContext;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.spel.ExtensionAwareEvaluationContextProvider;
+import org.springframework.data.spel.spi.EvaluationContextExtension;
+
+/**
+ * Unit tests for {@link BasicKeyValuePersistentEntity}.
+ *
+ * @author Mark Paluch
+ */
+public class BasicKeyValuePersistentEntityUnitTests {
+
+	MappingContext<? extends KeyValuePersistentEntity<?, ?>, ? extends KeyValuePersistentProperty<?>> mappingContext = new KeyValueMappingContext<>();
+
+	@Test // DATAKV-268
+	public void shouldDeriveKeyspaceFromClassName() {
+
+		KeyValuePersistentEntity<?, ?> persistentEntity = mappingContext.getPersistentEntity(KeyspaceEntity.class);
+
+		assertThat(persistentEntity.getKeySpace()).isEqualTo(KeyspaceEntity.class.getName());
+	}
+
+	@Test // DATAKV-268
+	public void shouldEvaluateKeyspaceExpression() {
+
+		KeyValuePersistentEntity<?, ?> persistentEntity = mappingContext.getPersistentEntity(ExpressionEntity.class);
+
+		persistentEntity.setEvaluationContextProvider(
+				new ExtensionAwareEvaluationContextProvider(Collections.singletonList(new SampleExtension())));
+
+		assertThat(persistentEntity.getKeySpace()).isEqualTo("some");
+	}
+
+	@KeySpace("#{myProperty}")
+	static class ExpressionEntity {}
+
+	@KeySpace
+	static class KeyspaceEntity {}
+
+	static class SampleExtension implements EvaluationContextExtension {
+
+		@Override
+		public String getExtensionId() {
+			return "sampleExtension";
+		}
+
+		@Override
+		public Map<String, Object> getProperties() {
+
+			Map<String, Object> properties = new LinkedHashMap<>();
+			properties.put("myProperty", "some");
+			return properties;
+		}
+	}
+}


### PR DESCRIPTION
We now support SpEL expressions in `@KeySpace` that gets evaluated on a per-operation basis.

```java
@KeySpace("#{myProperty}")
class Person {}
```

---

Related ticket: [DATAKV-268](https://jira.spring.io/browse/DATAKV-268).