### PR TITLE
DATAKV-290 - Synchronize creation of keyspace map

### DIFF
--- a/src/main/java/org/springframework/data/map/MapKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/map/MapKeyValueAdapter.java
@@ -186,24 +186,8 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 	 * @return
 	 */
 	protected Map<Object, Object> getKeySpaceMap(String keyspace) {
-
 		Assert.notNull(keyspace, "Collection must not be null for lookup.");
-
-		Map<Object, Object> map = store.get(keyspace);
-		if (map == null) {
-			synchronized (this) {
-				map = store.get(keyspace);
-				if (map == null) {
-					addMapForKeySpace(keyspace);
-					map = store.get(keyspace);
-				}
-			}
-		}
-
-		return map;
+		return store.computeIfAbsent(keyspace, k -> CollectionFactory.createMap(keySpaceMapType,  1000));
 	}
 
-	private void addMapForKeySpace(String keyspace) {
-		store.put(keyspace, CollectionFactory.createMap(keySpaceMapType, 1000));
-	}
 }

--- a/src/main/java/org/springframework/data/map/MapKeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/map/MapKeyValueAdapter.java
@@ -190,13 +190,17 @@ public class MapKeyValueAdapter extends AbstractKeyValueAdapter {
 		Assert.notNull(keyspace, "Collection must not be null for lookup.");
 
 		Map<Object, Object> map = store.get(keyspace);
-
-		if (map != null) {
-			return map;
+		if (map == null) {
+			synchronized (this) {
+				map = store.get(keyspace);
+				if (map == null) {
+					addMapForKeySpace(keyspace);
+					map = store.get(keyspace);
+				}
+			}
 		}
 
-		addMapForKeySpace(keyspace);
-		return store.get(keyspace);
+		return map;
 	}
 
 	private void addMapForKeySpace(String keyspace) {


### PR DESCRIPTION
The method getKeySpaceMap in MapKeyValueAdapter does not synchronize creation of the key space map. This results in data loss if multiple threads attempt to create the keyspace map as the map will be overwritten in the store after data is saved.

To resolve, adding the keyspace map to the store should be synchronized.