### PR TITLE
DATAKV-310 - Guard repository implementations against null values.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ This module provides infrastructure components to build repository abstractions 
 
 == Code of Conduct
 
-This project is governed by the link:CODE_OF_CONDUCT.adoc[Spring Code of Conduct]. By participating, you are expected to uphold this code of conduct. Please report unacceptable behavior to spring-code-of-conduct@pivotal.io.
+This project is governed by the https://github.com/spring-projects/.github/CODE_OF_CONDUCT.adoc[Spring Code of Conduct]. By participating, you are expected to uphold this code of conduct. Please report unacceptable behavior to spring-code-of-conduct@pivotal.io.
 
 == Getting Started
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-DATAKV-310-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/QuerydslKeyValueRepository.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/QuerydslKeyValueRepository.java
@@ -96,6 +96,8 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 	@Override
 	public Optional<T> findOne(Predicate predicate) {
 
+		Assert.notNull(predicate, "Predicate must not be null");
+
 		try {
 			return Optional.ofNullable(prepareQuery(predicate).fetchOne());
 		} catch (NonUniqueResultException o_O) {
@@ -109,6 +111,9 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 	 */
 	@Override
 	public Iterable<T> findAll(Predicate predicate) {
+
+		Assert.notNull(predicate, "Predicate must not be null");
+
 		return prepareQuery(predicate).fetchResults().getResults();
 	}
 
@@ -118,6 +123,9 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 	 */
 	@Override
 	public Iterable<T> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
+
+		Assert.notNull(predicate, "Predicate must not be null");
+		Assert.notNull(orders, "OrderSpecifiers must not be null");
 
 		AbstractCollQuery<T, ?> query = prepareQuery(predicate);
 		query.orderBy(orders);
@@ -131,6 +139,10 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 	 */
 	@Override
 	public Iterable<T> findAll(Predicate predicate, Sort sort) {
+
+		Assert.notNull(predicate, "Predicate must not be null");
+		Assert.notNull(sort, "Sort must not be null");
+
 		return findAll(predicate, toOrderSpecifier(sort, builder));
 	}
 
@@ -140,6 +152,9 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 	 */
 	@Override
 	public Page<T> findAll(Predicate predicate, Pageable pageable) {
+
+		Assert.notNull(predicate, "Predicate must not be null");
+		Assert.notNull(pageable, "Pageable must not be null");
 
 		AbstractCollQuery<T, ?> query = prepareQuery(predicate);
 
@@ -163,6 +178,8 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 	@Override
 	public Iterable<T> findAll(OrderSpecifier<?>... orders) {
 
+		Assert.notNull(orders, "OrderSpecifiers must not be null");
+
 		if (ObjectUtils.isEmpty(orders)) {
 			return findAll();
 		}
@@ -179,6 +196,9 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 	 */
 	@Override
 	public long count(Predicate predicate) {
+
+		Assert.notNull(predicate, "Predicate must not be null");
+
 		return prepareQuery(predicate).fetchCount();
 	}
 
@@ -188,6 +208,9 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 	 */
 	@Override
 	public boolean exists(Predicate predicate) {
+
+		Assert.notNull(predicate, "Predicate must not be null");
+
 		return count(predicate) > 0;
 	}
 

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/QuerydslKeyValueRepository.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/QuerydslKeyValueRepository.java
@@ -91,7 +91,7 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findOne(com.mysema.query.types.Predicate)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findOne(com.querydsl.core.types.Predicate)
 	 */
 	@Override
 	public Optional<T> findOne(Predicate predicate) {
@@ -107,7 +107,7 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.Predicate)
 	 */
 	@Override
 	public Iterable<T> findAll(Predicate predicate) {
@@ -119,7 +119,7 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, com.mysema.query.types.OrderSpecifier[])
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.Predicate, com.querydsl.core.types.OrderSpecifier[])
 	 */
 	@Override
 	public Iterable<T> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
@@ -135,7 +135,7 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Sort)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.Predicate, org.springframework.data.domain.Sort)
 	 */
 	@Override
 	public Iterable<T> findAll(Predicate predicate, Sort sort) {
@@ -148,7 +148,7 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.Predicate, org.springframework.data.domain.Pageable)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.Predicate, org.springframework.data.domain.Pageable)
 	 */
 	@Override
 	public Page<T> findAll(Predicate predicate, Pageable pageable) {
@@ -173,7 +173,7 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.mysema.query.types.OrderSpecifier[])
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#findAll(com.querydsl.core.types.OrderSpecifier[])
 	 */
 	@Override
 	public Iterable<T> findAll(OrderSpecifier<?>... orders) {
@@ -192,7 +192,7 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#count(com.mysema.query.types.Predicate)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#count(com.querydsl.core.types.Predicate)
 	 */
 	@Override
 	public long count(Predicate predicate) {
@@ -204,7 +204,7 @@ public class QuerydslKeyValueRepository<T, ID> extends SimpleKeyValueRepository<
 
 	/*
 	 * (non-Javadoc)
-	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#exists(com.mysema.query.types.Predicate)
+	 * @see org.springframework.data.querydsl.QueryDslPredicateExecutor#exists(com.querydsl.core.types.Predicate)
 	 */
 	@Override
 	public boolean exists(Predicate predicate) {

--- a/src/main/java/org/springframework/data/keyvalue/repository/support/SimpleKeyValueRepository.java
+++ b/src/main/java/org/springframework/data/keyvalue/repository/support/SimpleKeyValueRepository.java
@@ -64,6 +64,9 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 	 */
 	@Override
 	public Iterable<T> findAll(Sort sort) {
+
+		Assert.notNull(sort, "Sort must not be null!");
+
 		return operations.findAll(sort, entityInformation.getJavaType());
 	}
 
@@ -111,6 +114,8 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 	@Override
 	public <S extends T> Iterable<S> saveAll(Iterable<S> entities) {
 
+		Assert.notNull(entities, "The given Iterable of entities must not be null");
+
 		List<S> saved = new ArrayList<>();
 
 		for (S entity : entities) {
@@ -126,6 +131,9 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 	 */
 	@Override
 	public Optional<T> findById(ID id) {
+
+		Assert.notNull(id, "The given id must not be null");
+
 		return operations.findById(id, entityInformation.getJavaType());
 	}
 
@@ -154,6 +162,8 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 	@Override
 	public Iterable<T> findAllById(Iterable<ID> ids) {
 
+		Assert.notNull(ids, "The given Iterable of id's must not be null");
+
 		List<T> result = new ArrayList<>();
 
 		ids.forEach(id -> findById(id).ifPresent(result::add));
@@ -176,6 +186,9 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 	 */
 	@Override
 	public void deleteById(ID id) {
+
+		Assert.notNull(id, "The given id must not be null");
+
 		operations.delete(id, entityInformation.getJavaType());
 	}
 
@@ -185,6 +198,9 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 	 */
 	@Override
 	public void delete(T entity) {
+
+		Assert.notNull(entity, "The given entity must not be null");
+
 		deleteById(entityInformation.getRequiredId(entity));
 	}
 
@@ -194,6 +210,9 @@ public class SimpleKeyValueRepository<T, ID> implements KeyValueRepository<T, ID
 	 */
 	@Override
 	public void deleteAll(Iterable<? extends T> entities) {
+
+		Assert.notNull(entities, "The given Iterable of entities must not be null");
+
 		entities.forEach(this::delete);
 	}
 


### PR DESCRIPTION
`SimpleKeyValueRepository` and `QuerydslKeyValueRepository` now reject null arguments as per their interface contract.

---

Related ticket: DATAKV-310.