### PR TITLE
Accept target type in KeyValueAdapter.entries(…) and getAllOf(…)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>2.5.0-SNAPSHOT</version>
+	<version>2.5.0-GH-1995-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueAdapter.java
@@ -103,12 +103,38 @@ public interface KeyValueAdapter extends DisposableBean {
 	Iterable<?> getAllOf(String keyspace);
 
 	/**
+	 * Get all elements for given keyspace.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @param keyspace must not be {@literal null}.
+	 * @return empty {@link Collection} if nothing found.
+	 * @since 2.5
+	 */
+	@SuppressWarnings("unchecked")
+	default <T> Iterable<T> getAllOf(String keyspace, Class<T> type) {
+		return (Iterable<T>) getAllOf(keyspace);
+	}
+
+	/**
 	 * Returns a {@link CloseableIterator} that iterates over all entries.
 	 *
 	 * @param keyspace must not be {@literal null}.
 	 * @return
 	 */
 	CloseableIterator<Map.Entry<Object, Object>> entries(String keyspace);
+
+	/**
+	 * Returns a {@link CloseableIterator} that iterates over all entries.
+	 *
+	 * @param type must not be {@literal null}.
+	 * @param keyspace must not be {@literal null}.
+	 * @return
+	 * @since 2.5
+	 */
+	@SuppressWarnings("unchecked")
+	default <T> CloseableIterator<Map.Entry<Object, T>> entries(String keyspace, Class<T> type) {
+		return (CloseableIterator) entries(keyspace);
+	}
 
 	/**
 	 * Remove all objects of given type.
@@ -129,7 +155,9 @@ public interface KeyValueAdapter extends DisposableBean {
 	 * @param keyspace must not be {@literal null}.
 	 * @return empty {@link Collection} if no match found.
 	 */
-	Iterable<?> find(KeyValueQuery<?> query, String keyspace);
+	default Iterable<?> find(KeyValueQuery<?> query, String keyspace) {
+		return find(query, keyspace, Object.class);
+	}
 
 	/**
 	 * @param query must not be {@literal null}.

--- a/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/KeyValueTemplate.java
@@ -237,7 +237,7 @@ public class KeyValueTemplate implements KeyValueOperations, ApplicationEventPub
 
 		return executeRequired(adapter -> {
 
-			Iterable<?> values = adapter.getAllOf(resolveKeySpace(type));
+			Iterable<?> values = adapter.getAllOf(resolveKeySpace(type), type);
 
 			ArrayList<T> filtered = new ArrayList<>();
 			for (Object candidate : values) {

--- a/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/KeyValueTemplateUnitTests.java
@@ -190,7 +190,7 @@ class KeyValueTemplateUnitTests {
 
 		template.findAll(Foo.class);
 
-		verify(adapterMock, times(1)).getAllOf(Foo.class.getName());
+		verify(adapterMock, times(1)).getAllOf(Foo.class.getName(), Foo.class);
 	}
 
 	@Test // DATACMNS-525
@@ -327,7 +327,7 @@ class KeyValueTemplateUnitTests {
 	void findAllOfShouldRespectTypeAliasAndFilterNonMatchingTypes() {
 
 		Collection foo = Arrays.asList(ALIASED_USING_ALIAS_FOR, SUBCLASS_OF_ALIASED_USING_ALIAS_FOR);
-		when(adapterMock.getAllOf("aliased")).thenReturn(foo);
+		when(adapterMock.getAllOf("aliased", SUBCLASS_OF_ALIASED_USING_ALIAS_FOR.getClass())).thenReturn(foo);
 
 		assertThat((Iterable) template.findAll(SUBCLASS_OF_ALIASED_USING_ALIAS_FOR.getClass()))
 				.contains(SUBCLASS_OF_ALIASED_USING_ALIAS_FOR);


### PR DESCRIPTION
We now accept the target type in both methods to retain type hints so that the underlying adapter implementation can use this type when materializing object instances.

---

Related ticket: https://github.com/spring-projects/spring-data-redis/issues/1995