### PR TITLE
Fix flakey tests

### DIFF
--- a/src/test/java/org/springframework/data/map/MapKeyValueAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/map/MapKeyValueAdapterUnitTests.java
@@ -29,6 +29,7 @@ import org.springframework.data.util.CloseableIterator;
 
 /**
  * @author Christoph Strobl
+ * @author Hang Xie
  */
 class MapKeyValueAdapterUnitTests {
 

--- a/src/test/java/org/springframework/data/map/MapKeyValueAdapterUnitTests.java
+++ b/src/test/java/org/springframework/data/map/MapKeyValueAdapterUnitTests.java
@@ -147,8 +147,17 @@ class MapKeyValueAdapterUnitTests {
 
 		CloseableIterator<Map.Entry<Object, Object>> iterator = adapter.entries(COLLECTION_1);
 
-		assertThat(iterator.next()).isEqualTo(new AbstractMap.SimpleEntry<>("1", object1));
-		assertThat(iterator.next()).isEqualTo(new AbstractMap.SimpleEntry<>("2", object2));
+		Map.Entry<Object, Object> entry1 = iterator.next();
+		Map.Entry<Object, Object> entry2 = iterator.next();
+
+		if(entry1.getKey().equals("1")) {
+			assertThat(entry1).isEqualTo(new AbstractMap.SimpleEntry<>("1", object1));
+			assertThat(entry2).isEqualTo(new AbstractMap.SimpleEntry<>("2", object2));
+		} else {
+			assertThat(entry2).isEqualTo(new AbstractMap.SimpleEntry<>("2", object2));
+			assertThat(entry1).isEqualTo(new AbstractMap.SimpleEntry<>("1", object1));
+		}
+
 		assertThat(iterator.hasNext()).isFalse();
 	}
 
@@ -165,7 +174,14 @@ class MapKeyValueAdapterUnitTests {
 
 		CloseableIterator<Map.Entry<Object, Object>> iterator = adapter.entries(COLLECTION_1);
 
-		assertThat(iterator.next()).isEqualTo(new AbstractMap.SimpleEntry<>("1", object1));
+		Map.Entry<Object, Object> entry1 = iterator.next();
+
+		if(entry1.getKey().equals("1")) {
+			assertThat(entry1).isEqualTo(new AbstractMap.SimpleEntry<>("1", object1));
+		} else {
+			assertThat(entry1).isEqualTo(new AbstractMap.SimpleEntry<>("2", object2));
+		}
+
 		assertThat(iterator.hasNext()).isFalse();
 	}
 


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [☑️] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [☑️] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [☑️] You submit test cases (unit or integration tests) that back your changes.
- [☑️] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

---

This PR fixes 2 potential flaky tests in `MapKeyValueAdapterUnitTests.java` file.

In the test `scanShouldIterateOverAvailableEntries()`, we rely on the fact that the map has a specific order. However, as the key space map for COLLECTION_1 is initialized as a `ConcurrentHashMap`, it is not guaranteed that the order will remain constant over time according to the [Java documentation](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html).

> Because the elements of a ConcurrentHashMap are not ordered in any particular way, and may be processed in different orders in different parallel executions, the correctness of supplied functions should not depend on any ordering, or on any other objects or values that may transiently change while computation is in progress;

Such indeterministic characteristic of ConcurrentHashMap will cause this test to fail in some platforms or specific machines that adopt a different iteration order.

To fix it, I will first iterate through all the entries in the map, and based on the key of the first entry, we then compare two entries accordingly. 

The same fix also applies to `scanDoesNotMixResultsFromMultipleKeyspaces()`. 