### PR TITLE
Support adding a key prefix for keyspaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-GH-461-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/AnnotationBasedKeySpaceResolver.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/AnnotationBasedKeySpaceResolver.java
@@ -31,7 +31,7 @@ import org.springframework.util.ClassUtils;
  * @author Oliver Gierke
  * @author Mark Paluch
  */
-enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
+public enum AnnotationBasedKeySpaceResolver implements KeySpaceResolver {
 
 	INSTANCE;
 

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/BasicKeyValuePersistentEntity.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/BasicKeyValuePersistentEntity.java
@@ -25,7 +25,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
- * {@link KeyValuePersistentEntity} implementation that adds specific meta-data such as the {@literal keySpace}..
+ * {@link KeyValuePersistentEntity} implementation that adds specific meta-data such as the {@literal keySpace}.
  *
  * @author Christoph Strobl
  * @author Oliver Gierke
@@ -37,31 +37,47 @@ public class BasicKeyValuePersistentEntity<T, P extends KeyValuePersistentProper
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
-	private static final KeySpaceResolver DEFAULT_FALLBACK_RESOLVER = ClassNameKeySpaceResolver.INSTANCE;
-
 	private final @Nullable Expression keyspaceExpression;
 	private final @Nullable String keyspace;
 
 	/**
 	 * @param information must not be {@literal null}.
-	 * @param fallbackKeySpaceResolver can be {@literal null}.
+	 * @since 3.0
 	 */
-	public BasicKeyValuePersistentEntity(TypeInformation<T> information,
-			@Nullable KeySpaceResolver fallbackKeySpaceResolver) {
+	public BasicKeyValuePersistentEntity(TypeInformation<T> information) {
+		this(information, (String) null);
+	}
+
+	/**
+	 * @param information must not be {@literal null}.
+	 * @param keySpaceResolver can be {@literal null}.
+	 */
+	public BasicKeyValuePersistentEntity(TypeInformation<T> information, @Nullable KeySpaceResolver keySpaceResolver) {
+		this(information, keySpaceResolver != null ? keySpaceResolver.resolveKeySpace(information.getType()) : null);
+	}
+
+	private BasicKeyValuePersistentEntity(TypeInformation<T> information, @Nullable String keyspace) {
 
 		super(information);
 
-		Class<T> type = information.getType();
-		String keySpace = AnnotationBasedKeySpaceResolver.INSTANCE.resolveKeySpace(type);
+		if (StringUtils.hasText(keyspace)) {
 
-		if (StringUtils.hasText(keySpace)) {
-
-			this.keyspace = keySpace;
-			this.keyspaceExpression = detectExpression(keySpace);
+			this.keyspace = keyspace;
+			this.keyspaceExpression = null;
 		} else {
 
-			this.keyspace = resolveKeyspace(fallbackKeySpaceResolver, type);
-			this.keyspaceExpression = null;
+			Class<T> type = information.getType();
+			String detectedKeyspace = AnnotationBasedKeySpaceResolver.INSTANCE.resolveKeySpace(type);
+
+			if (StringUtils.hasText(detectedKeyspace)) {
+
+				this.keyspace = detectedKeyspace;
+				this.keyspaceExpression = detectExpression(detectedKeyspace);
+			} else {
+
+				this.keyspace = ClassNameKeySpaceResolver.INSTANCE.resolveKeySpace(type);
+				this.keyspaceExpression = null;
+			}
 		}
 	}
 
@@ -77,12 +93,6 @@ public class BasicKeyValuePersistentEntity<T, P extends KeyValuePersistentProper
 
 		Expression expression = PARSER.parseExpression(potentialExpression, ParserContext.TEMPLATE_EXPRESSION);
 		return expression instanceof LiteralExpression ? null : expression;
-	}
-
-	@Nullable
-	private static String resolveKeyspace(@Nullable KeySpaceResolver fallbackKeySpaceResolver, Class<?> type) {
-		return (fallbackKeySpaceResolver == null ? DEFAULT_FALLBACK_RESOLVER : fallbackKeySpaceResolver)
-				.resolveKeySpace(type);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/ClassNameKeySpaceResolver.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/ClassNameKeySpaceResolver.java
@@ -24,7 +24,7 @@ import org.springframework.util.ClassUtils;
  * @author Christoph Strobl
  * @author Oliver Gierke
  */
-enum ClassNameKeySpaceResolver implements KeySpaceResolver {
+public enum ClassNameKeySpaceResolver implements KeySpaceResolver {
 
 	INSTANCE;
 

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/KeySpaceResolver.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/KeySpaceResolver.java
@@ -19,7 +19,7 @@ import org.springframework.lang.Nullable;
 
 /**
  * {@link KeySpaceResolver} determines the {@literal keyspace} a given type is assigned to. A keyspace in this context
- * is a specific region/collection/grouping of elements sharing a common keyrange. <br />
+ * is a specific region/collection/grouping of elements sharing a common keyrange.
  *
  * @author Christoph Strobl
  * @author Mark Paluch

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/PrefixKeyspaceResolver.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/PrefixKeyspaceResolver.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.keyvalue.core.mapping;
+
+import org.springframework.util.Assert;
+
+/**
+ * {@link KeySpaceResolver} prefixing the {@literal keyspace} with a static prefix after determining the keyspace from a
+ * delegate {@link KeySpaceResolver}.
+ *
+ * @author Mark Paluch
+ * @since 3.0
+ */
+public class PrefixKeyspaceResolver implements KeySpaceResolver {
+
+	private final String prefix;
+	private final KeySpaceResolver delegate;
+
+	public PrefixKeyspaceResolver(String prefix, KeySpaceResolver delegate) {
+
+		Assert.notNull(prefix, "Prefix must not be null");
+		Assert.notNull(delegate, "Delegate KeySpaceResolver must not be null");
+
+		this.prefix = prefix;
+		this.delegate = delegate;
+	}
+
+	@Override
+	public String resolveKeySpace(Class<?> type) {
+		return prefix + delegate.resolveKeySpace(type);
+	}
+
+}

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/context/KeyValueMappingContext.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/context/KeyValueMappingContext.java
@@ -39,7 +39,7 @@ import org.springframework.lang.Nullable;
 public class KeyValueMappingContext<E extends KeyValuePersistentEntity<?, P>, P extends KeyValuePersistentProperty<P>>
 		extends AbstractMappingContext<E, P> {
 
-	private @Nullable KeySpaceResolver fallbackKeySpaceResolver;
+	private @Nullable KeySpaceResolver keySpaceResolver;
 
 	public KeyValueMappingContext() {
 		setSimpleTypeHolder(new KeyValueSimpleTypeHolder());
@@ -49,24 +49,37 @@ public class KeyValueMappingContext<E extends KeyValuePersistentEntity<?, P>, P 
 	 * Configures the {@link KeySpaceResolver} to be used if not explicit key space is annotated to the domain type.
 	 *
 	 * @param fallbackKeySpaceResolver can be {@literal null}.
+	 * @deprecated since 3.0, use {@link KeySpaceResolver} instead.
 	 */
+	@Deprecated(since = "3.0")
 	public void setFallbackKeySpaceResolver(KeySpaceResolver fallbackKeySpaceResolver) {
-		this.fallbackKeySpaceResolver = fallbackKeySpaceResolver;
+		setKeySpaceResolver(fallbackKeySpaceResolver);
 	}
 
 	/**
-	 * @return the current fallback KeySpaceResolver. Can be {@literal null}.
+	 * Configures the {@link KeySpaceResolver} to be used. Configuring a {@link KeySpaceResolver} disables SpEL evaluation
+	 * abilities.
+	 *
+	 * @param keySpaceResolver can be {@literal null}.
+	 * @since 3.0
+	 */
+	public void setKeySpaceResolver(KeySpaceResolver keySpaceResolver) {
+		this.keySpaceResolver = keySpaceResolver;
+	}
+
+	/**
+	 * @return the current {@link KeySpaceResolver}. Can be {@literal null}.
 	 * @since 3.0
 	 */
 	@Nullable
-	public KeySpaceResolver getFallbackKeySpaceResolver() {
-		return fallbackKeySpaceResolver;
+	public KeySpaceResolver getKeySpaceResolver() {
+		return keySpaceResolver;
 	}
 
 	@Override
 	@SuppressWarnings("unchecked")
 	protected <T> E createPersistentEntity(TypeInformation<T> typeInformation) {
-		return (E) new BasicKeyValuePersistentEntity<T, P>(typeInformation, getFallbackKeySpaceResolver());
+		return (E) new BasicKeyValuePersistentEntity<T, P>(typeInformation, getKeySpaceResolver());
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/keyvalue/core/mapping/context/KeyValueMappingContext.java
+++ b/src/main/java/org/springframework/data/keyvalue/core/mapping/context/KeyValueMappingContext.java
@@ -54,10 +54,19 @@ public class KeyValueMappingContext<E extends KeyValuePersistentEntity<?, P>, P 
 		this.fallbackKeySpaceResolver = fallbackKeySpaceResolver;
 	}
 
+	/**
+	 * @return the current fallback KeySpaceResolver. Can be {@literal null}.
+	 * @since 3.0
+	 */
+	@Nullable
+	public KeySpaceResolver getFallbackKeySpaceResolver() {
+		return fallbackKeySpaceResolver;
+	}
+
 	@Override
 	@SuppressWarnings("unchecked")
 	protected <T> E createPersistentEntity(TypeInformation<T> typeInformation) {
-		return (E) new BasicKeyValuePersistentEntity<T, P>(typeInformation, fallbackKeySpaceResolver);
+		return (E) new BasicKeyValuePersistentEntity<T, P>(typeInformation, getFallbackKeySpaceResolver());
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/keyvalue/core/mapping/PrefixKeyspaceResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/keyvalue/core/mapping/PrefixKeyspaceResolverUnitTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.keyvalue.core.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PrefixKeyspaceResolver}.
+ *
+ * @author Mark Paluch
+ */
+class PrefixKeyspaceResolverUnitTests {
+
+	@Test // gh-461
+	void shouldApplyPrefix() {
+
+		var resolver = new PrefixKeyspaceResolver("foo", Class::getSimpleName);
+
+		assertThat(resolver.resolveKeySpace(Object.class)).isEqualTo("fooObject");
+	}
+}


### PR DESCRIPTION
A configured KeySpaceResolver is now used primarily to detect the KeySpace to allow further customization of the KeySpace detection strategy.

The concept of a fallback resolver is now deprecated.