### PR TITLE
Correct the README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,8 +10,12 @@ This module provides infrastructure components to build repository abstractions 
 * `java.util.function.Predicate` based query generation from query method names.
 * Possibility to integrate custom repository code.
 
-include::https://raw.githubusercontent.com/spring-projects/spring-data-build/refs/heads/main/etc/readme/code-of-conduct.adoc[]
+[[code-of-conduct]]
+== Code of Conduct
 
+This project is governed by the https://github.com/spring-projects/.github/blob/main/CODE_OF_CONDUCT.md[Spring Code of Conduct]. By participating, you are expected to uphold this code of conduct. Please report unacceptable behavior to spring-code-of-conduct@spring.io.
+
+[[getting-started]]
 == Getting Started
 
 Here is a quick teaser of an application using Spring Data Repositories in Java:
@@ -63,8 +67,102 @@ class Person {
 class AppConfig { … }
 ----
 
-include::https://raw.githubusercontent.com/spring-projects/spring-data-build/refs/heads/main/etc/readme/dependencies.adoc[]
+[[maven-configuration]]
+=== Maven configuration
 
-include::https://raw.githubusercontent.com/spring-projects/spring-data-build/refs/heads/main/etc/readme/getting-help.adoc[]
+Add the Maven dependency:
 
-include::https://raw.githubusercontent.com/spring-projects/spring-data-build/refs/heads/main/etc/readme/license.adoc[]
+[source,xml]
+----
+<dependency>
+  <groupId>org.springframework.data</groupId>
+  <artifactId>spring-data-keyvalue</artifactId>
+  <version>${version}</version>
+</dependency>
+----
+
+If you'd rather like the latest snapshots of the upcoming major version, use our Maven snapshot repository and declare the appropriate dependency version.
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.springframework.data</groupId>
+  <artifactId>spring-data-keyvalue</artifactId>
+  <version>${version}-SNAPSHOT</version>
+</dependency>
+
+<repository>
+  <id>spring-snapshot</id>
+  <name>Spring Snapshot Repository</name>
+  <url>https://repo.spring.io/snapshot</url>
+</repository>
+----
+
+[[upgrading]]
+== Upgrading
+
+Instructions for how to upgrade from earlier versions of Spring Data are provided on the project https://github.com/spring-projects/spring-data-commons/wiki[wiki].
+Follow the links in the https://github.com/spring-projects/spring-data-commons/wiki#release-notes[release notes section] to find the version that you want to upgrade to.
+
+[[getting-help]]
+== Getting Help
+
+Having trouble with Spring Data? We’d love to help!
+
+* Check the
+https://docs.spring.io/spring-data/keyvalue/reference/[reference documentation], and https://docs.spring.io/spring-data/keyvalue/docs/current/api/[Javadocs].
+* Learn the Spring basics - Spring Data builds on Spring Framework, check the https://spring.io[spring.io] web-site for a wealth of reference documentation.
+If you are just starting out with Spring, try one of the https://spring.io/guides[guides].
+* If you are upgrading, check out the https://github.com/spring-projects/spring-data-keyvalue/releases[GitHub releases] and the https://github.com/spring-projects/spring-data-keyvalue/wiki#release-notes[release notes] for "`new and noteworthy`" features.
+* Report bugs with Spring Data KeyValue at https://github.com/spring-projects/spring-data-keyvalue/issues[GitHub Issues].
+
+[[reporting-issues]]
+== Reporting Issues
+
+Spring Data uses GitHub as issue tracking system to record bugs and feature requests. If you want to raise an issue, please follow the recommendations below:
+
+* Before you log a bug, please search the
+https://github.com/spring-projects/spring-data-keyvalue/issues[issue tracker] to see if someone has already reported the problem.
+* If the issue doesn’t already exist, https://github.com/spring-projects/spring-data-keyvalue/issues/new[create a new issue].
+* Please provide as much information as possible with the issue report, we like to know the version of Spring Data that you are using and JVM version.
+* If you need to paste code, or include a stack trace use Markdown +++```+++ escapes before and after your text.
+* Please create a test-case or project that replicates the issue. Attach a link to your code or a compressed file containing your code.
+
+[[examples]]
+== Examples
+
+* https://github.com/spring-projects/spring-data-examples/[Spring Data Examples] contains example projects that explain specific features in more detail.
+
+[[building-from-source]]
+== Building from Source
+
+You don’t need to build from source to use Spring Data (binaries in https://repo.spring.io[repo.spring.io]), but if you want to try out the latest and greatest, Spring Data can be easily built with the https://github.com/apache/maven-wrapper[maven wrapper].
+You also need JDK 17 or above.
+
+[source,bash]
+----
+ $ ./mvnw clean install
+----
+
+If you want to build with the regular `mvn` command, you will need https://maven.apache.org/run-maven/index.html[Maven v3.9.0 or above].
+
+_Also see link:CONTRIBUTING.adoc[CONTRIBUTING.adoc] if you wish to submit pull requests._
+All commits must include a __Signed-off-by__ trailer at the end of each commit message to indicate that the contributor agrees to the Developer Certificate of Origin.
+For additional details, please refer to the blog post https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring[Hello DCO, Goodbye CLA: Simplifying Contributions to Spring].
+
+[[building-documentation]]
+=== Building reference documentation
+
+Building the documentation builds also the project without running tests.
+
+[source,bash]
+----
+ $ ./mvnw clean install -Pantora
+----
+
+The generated documentation is available from `target/site/index.html`.
+
+[[license]]
+== License
+
+Spring Data KeyValue is Open Source software released under the https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ This module provides infrastructure components to build repository abstractions 
 == Features
 
 * Infrastructure for building repositories on top of key/value implementations.
-* Dynamic SpEL query generation from query method names.
+* `java.util.function.Predicate` based query generation from query method names.
 * Possibility to integrate custom repository code.
 
 include::https://raw.githubusercontent.com/spring-projects/spring-data-build/refs/heads/main/etc/readme/code-of-conduct.adoc[]

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-keyvalue</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-691-SNAPSHOT</version>
 
 	<name>Spring Data KeyValue</name>
 


### PR DESCRIPTION
Fix query generation in README

Includes, which don't work on Github README files are replaced by actual text snippets, as it is the case in other Spring Data modules.

Closes #691